### PR TITLE
Fix AMD SMI accessor signatures and link order

### DIFF
--- a/src/components/amd_smi/Rules.amd_smi
+++ b/src/components/amd_smi/Rules.amd_smi
@@ -75,13 +75,13 @@ PAPI_AMDSMI_ROOT ?= /opt/rocm
 # for disabling is shown using the papi utility,
 # papi/src/utils/papi_component_avail. 
 
-COMPSRCS += components/amd_smi/linux-amd-smi.c \
-            components/amd_smi/amds.c \
+COMPSRCS += components/amd_smi/amds.c \
+            components/amd_smi/linux-amd-smi.c \
             components/amd_smi/amds_accessors.c \
             components/amd_smi/amds_evtapi.c \
             components/amd_smi/amds_ctx.c
-COMPOBJS += linux-amd-smi.o \
-            amds.o \
+COMPOBJS += amds.o \
+            linux-amd-smi.o \
             amds_accessors.o \
             amds_evtapi.o \
             amds_ctx.o

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -13,6 +13,8 @@ typedef enum {
   PAPI_MODE_RDWR,
 } rocs_access_mode_e;
 
+typedef int (*amds_accessor_t)(int mode, void *arg);
+
 /* Native event descriptor */
 typedef struct native_event {
   unsigned int id;
@@ -24,7 +26,7 @@ typedef struct native_event {
   int (*close_func)(struct native_event *);
   int (*start_func)(struct native_event *);
   int (*stop_func)(struct native_event *);
-  int (*access_func)(int mode, void *arg);
+  amds_accessor_t access_func;
 } native_event_t;
 
 typedef struct {


### PR DESCRIPTION
## Summary
- Introduce a dedicated `amds_accessor_t` type and use it for event accessors to resolve function-pointer signature mismatches
- Reorder AMD SMI component sources and objects so core functionality is linked ahead of the wrapper, preventing undefined reference errors

## Testing
- `make components/amd_smi/amds.o` *(fails: fatal error: amdsmi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b08da2f690832bba597cb17a50603d