### PR TITLE
Guard unsupported AMD SMI features

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -175,8 +175,10 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_gpu_id_p = sym("amdsmi_get_gpu_id", NULL);
   amdsmi_get_gpu_revision_p = sym("amdsmi_get_gpu_revision", NULL);
   amdsmi_get_gpu_subsystem_id_p = sym("amdsmi_get_gpu_subsystem_id", NULL);
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
   amdsmi_get_gpu_virtualization_mode_p =
       sym("amdsmi_get_gpu_virtualization_mode", NULL);
+#endif
   amdsmi_get_gpu_process_isolation_p =
       sym("amdsmi_get_gpu_process_isolation", NULL);
   amdsmi_get_gpu_xcd_counter_p = sym("amdsmi_get_gpu_xcd_counter", NULL);
@@ -195,8 +197,10 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_fw_info_p = sym("amdsmi_get_fw_info", NULL);
   amdsmi_get_gpu_vbios_info_p = sym("amdsmi_get_gpu_vbios_info", NULL);
   amdsmi_get_gpu_device_uuid_p = sym("amdsmi_get_gpu_device_uuid", NULL);
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
   amdsmi_get_gpu_enumeration_info_p =
       sym("amdsmi_get_gpu_enumeration_info", NULL);
+#endif
   amdsmi_get_gpu_vendor_name_p = sym("amdsmi_get_gpu_vendor_name", NULL);
   amdsmi_get_gpu_vram_vendor_p = sym("amdsmi_get_gpu_vram_vendor", NULL);
   amdsmi_get_gpu_subsystem_name_p = sym("amdsmi_get_gpu_subsystem_name", NULL);
@@ -756,6 +760,7 @@ static int init_event_table(void) {
           return PAPI_ENOMEM;
         }
 
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
         CHECK_EVENT_IDX(idx);
         snprintf(name_buf, sizeof(name_buf),
                  "pcie_max_interface_version:device=%d", d);
@@ -765,6 +770,7 @@ static int init_event_table(void) {
                       access_amdsmi_pcie_info) != PAPI_OK) {
           return PAPI_ENOMEM;
         }
+#endif
 
         CHECK_EVENT_IDX(idx);
         snprintf(name_buf, sizeof(name_buf), "pcie_width:device=%d", d);
@@ -1712,6 +1718,7 @@ static int init_event_table(void) {
         return PAPI_ENOMEM;
       }
     }
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
     // GPU Virtualization Mode
     amdsmi_virtualization_mode_t vmode;
     if (amdsmi_get_gpu_virtualization_mode_p &&
@@ -1726,6 +1733,7 @@ static int init_event_table(void) {
         return PAPI_ENOMEM;
       }
     }
+#endif
     // GPU NUMA Node
     if (amdsmi_get_gpu_topo_numa_affinity_p(device_handles[d], &numa) ==
         AMDSMI_STATUS_SUCCESS) {
@@ -1801,6 +1809,7 @@ static int init_event_table(void) {
       }
     }
 
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
     if (amdsmi_get_gpu_vram_info_p) {
       amdsmi_vram_info_t vinfo;
       if (amdsmi_get_gpu_vram_info_p(device_handles[d], &vinfo) ==
@@ -1815,6 +1824,7 @@ static int init_event_table(void) {
         }
       }
     }
+#endif
 
     if (amdsmi_get_gpu_bad_page_info_p) {
       uint32_t nump = 0;
@@ -1884,6 +1894,7 @@ static int init_event_table(void) {
           break;
 
         /* Register current socket power in Watts */
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
         CHECK_EVENT_IDX(idx);
         snprintf(name_buf, sizeof(name_buf),
                  "power_sensor_current_watts:device=%d:sensor=%u", d, s);
@@ -1893,6 +1904,7 @@ static int init_event_table(void) {
                       access_amdsmi_power_sensor) != PAPI_OK) {
           return PAPI_ENOMEM;
         }
+#endif
 
         /* Register average socket power in Watts */
         CHECK_EVENT_IDX(idx);
@@ -1906,6 +1918,7 @@ static int init_event_table(void) {
         }
 
         /* Register socket power in microwatts */
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
         CHECK_EVENT_IDX(idx);
         snprintf(name_buf, sizeof(name_buf),
                  "power_sensor_socket_microwatts:device=%d:sensor=%u", d, s);
@@ -1915,6 +1928,7 @@ static int init_event_table(void) {
                       access_amdsmi_power_sensor) != PAPI_OK) {
           return PAPI_ENOMEM;
         }
+#endif
 
         /* Register GFX voltage */
         CHECK_EVENT_IDX(idx);
@@ -2479,6 +2493,7 @@ static int init_event_table(void) {
       }
     }
 
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
     /* Enumeration info (drm render/card, hsa/hip ids) */
     if (amdsmi_get_gpu_enumeration_info_p) {
       amdsmi_enumeration_info_t einfo;
@@ -2514,6 +2529,7 @@ static int init_event_table(void) {
         }
       }
     }
+#endif
     /* ASIC info (numeric IDs & CU count) */
     if (amdsmi_get_gpu_asic_info_p) {
       amdsmi_asic_info_t ainfo;

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -131,6 +131,7 @@ int access_amdsmi_gpu_string_hash(int mode, void *arg) {
   event->value = (int64_t)_str_to_u64_hash(buf);
   return PAPI_OK;
 }
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_enumeration_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
@@ -161,6 +162,7 @@ int access_amdsmi_enumeration_info(int mode, void *arg) {
   }
   return PAPI_OK;
 }
+#endif
 int access_amdsmi_asic_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
@@ -755,12 +757,16 @@ int access_amdsmi_gpu_info(int mode, void *arg) {
     break;
   }
   case 4: {
+    #if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
     amdsmi_virtualization_mode_t mode_val;
     status = amdsmi_get_gpu_virtualization_mode_p(device_handles[event->device], &mode_val);
     if (status == AMDSMI_STATUS_SUCCESS) {
       event->value = mode_val;
     }
     break;
+    #else
+    return PAPI_ENOSUPP;
+    #endif
   }
   case 5: {
     int32_t numa_node = -1;
@@ -1831,6 +1837,7 @@ int access_amdsmi_fw_version(int mode, void *arg) {
   return PAPI_EMISC;
 }
 
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
@@ -1846,6 +1853,7 @@ int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   event->value = (int64_t)info.vram_max_bandwidth; /* GB/s */
   return PAPI_OK;
 }
+#endif
 
 int access_amdsmi_bad_page_count(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
@@ -1932,15 +1940,19 @@ int access_amdsmi_power_sensor(int mode, void *arg) {
   if (st != AMDSMI_STATUS_SUCCESS)
     return PAPI_EMISC;
   switch (event->variant) {
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
   case 0:
     event->value = (int64_t)info.current_socket_power;
     break;
+#endif
   case 1:
     event->value = (int64_t)info.average_socket_power;
     break;
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
   case 2:
     event->value = (int64_t)info.socket_power;
     break;
+#endif
   case 3:
     event->value = (int64_t)info.gfx_voltage;
     break;
@@ -1984,9 +1996,11 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
   case 3:
     event->value = (int64_t)info.pcie_static.slot_type;
     break;
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
   case 4:
     event->value = (int64_t)info.pcie_static.max_pcie_interface_version;
     break;
+#endif
   case 5:
     event->value = info.pcie_metric.pcie_width;
     break;

--- a/src/components/amd_smi/amds_funcs.h
+++ b/src/components/amd_smi/amds_funcs.h
@@ -1,6 +1,8 @@
 #ifndef AMDS_FUNCS_H
 #define AMDS_FUNCS_H
 
+#include <amd_smi/amdsmi.h>
+
 #define AMD_SMI_GPU_FUNCTIONS(_)                                               \
   _(amdsmi_init_p, amdsmi_status_t, (uint64_t))                                \
   _(amdsmi_shut_down_p, amdsmi_status_t, (void))                               \
@@ -55,8 +57,10 @@
     (amdsmi_processor_handle, amdsmi_vbios_info_t *))                          \
   _(amdsmi_get_gpu_device_uuid_p, amdsmi_status_t,                             \
     (amdsmi_processor_handle, unsigned int *, char *))                         \
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25        \
   _(amdsmi_get_gpu_enumeration_info_p, amdsmi_status_t,                        \
     (amdsmi_processor_handle, amdsmi_enumeration_info_t *))                    \
+#endif                                                                         \
   _(amdsmi_get_gpu_vendor_name_p, amdsmi_status_t,                             \
     (amdsmi_processor_handle, char *, size_t))                                 \
   _(amdsmi_get_gpu_vram_vendor_p, amdsmi_status_t,                             \
@@ -88,8 +92,10 @@
     (amdsmi_processor_handle, uint16_t *))                                     \
   _(amdsmi_get_gpu_subsystem_id_p, amdsmi_status_t,                            \
     (amdsmi_processor_handle, uint16_t *))                                     \
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25        \
   _(amdsmi_get_gpu_virtualization_mode_p, amdsmi_status_t,                     \
     (amdsmi_processor_handle, amdsmi_virtualization_mode_t *))                 \
+#endif                                                                         \
   _(amdsmi_get_gpu_process_isolation_p, amdsmi_status_t,                       \
     (amdsmi_processor_handle, uint32_t *))                                     \
   _(amdsmi_get_gpu_xcd_counter_p, amdsmi_status_t,                             \

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -87,7 +87,9 @@ int access_amdsmi_energy_count(int mode, void *arg);
 int access_amdsmi_power_profile_status(int mode, void *arg);
 int access_amdsmi_uuid_hash(int mode, void *arg);
 int access_amdsmi_gpu_string_hash(int mode, void *arg);
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_enumeration_info(int mode, void *arg);
+#endif
 int access_amdsmi_asic_info(int mode, void *arg);
 int access_amdsmi_link_metrics(int mode, void *arg);
 int access_amdsmi_process_info(int mode, void *arg);
@@ -126,7 +128,9 @@ int access_amdsmi_xgmi_plpd_supported(int mode, void *arg);
 int access_amdsmi_process_isolation(int mode, void *arg);
 int access_amdsmi_xcd_counter(int mode, void *arg);
 int access_amdsmi_board_serial_hash(int mode, void *arg);
+#if defined(AMDSMI_LIB_VERSION_MAJOR) && AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
+#endif
 int access_amdsmi_fw_version(int mode, void *arg);
 int access_amdsmi_bad_page_count(int mode, void *arg);
 int access_amdsmi_bad_page_threshold(int mode, void *arg);


### PR DESCRIPTION
## Summary
- Include `amdsmi.h` and guard newer AMD SMI APIs with library version checks
- Skip enumeration, virtualization and bandwidth events when the library lacks support
- Protect power and PCIe sensor accessors from missing fields in older headers

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b217136670832ba6c3dba4ee765b56