### PR TITLE
Guard AMD SMI enumeration API when unavailable

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -45,7 +45,9 @@ amdsmi_status_t (*amdsmi_get_gpu_board_info_p)(amdsmi_processor_handle, amdsmi_b
 amdsmi_status_t (*amdsmi_get_fw_info_p)(amdsmi_processor_handle, amdsmi_fw_info_t *);
 amdsmi_status_t (*amdsmi_get_gpu_vbios_info_p)(amdsmi_processor_handle, amdsmi_vbios_info_t *);
 amdsmi_status_t (*amdsmi_get_gpu_device_uuid_p)(amdsmi_processor_handle, unsigned int *, char *);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
 amdsmi_status_t (*amdsmi_get_gpu_enumeration_info_p)(amdsmi_processor_handle, amdsmi_enumeration_info_t *);
+#endif
 amdsmi_status_t (*amdsmi_get_gpu_vendor_name_p)(amdsmi_processor_handle, char *, size_t);
 amdsmi_status_t (*amdsmi_get_gpu_vram_vendor_p)(amdsmi_processor_handle, char *, uint32_t);
 amdsmi_status_t (*amdsmi_get_gpu_subsystem_name_p)(amdsmi_processor_handle, char *, size_t);
@@ -229,7 +231,9 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_fw_info_p = sym("amdsmi_get_fw_info", NULL);
   amdsmi_get_gpu_vbios_info_p = sym("amdsmi_get_gpu_vbios_info", NULL);
   amdsmi_get_gpu_device_uuid_p = sym("amdsmi_get_gpu_device_uuid", NULL);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
   amdsmi_get_gpu_enumeration_info_p = sym("amdsmi_get_gpu_enumeration_info", NULL);
+#endif
   amdsmi_get_gpu_vendor_name_p = sym("amdsmi_get_gpu_vendor_name", NULL);
   amdsmi_get_gpu_vram_vendor_p = sym("amdsmi_get_gpu_vram_vendor", NULL);
   amdsmi_get_gpu_subsystem_name_p = sym("amdsmi_get_gpu_subsystem_name", NULL);
@@ -2224,6 +2228,7 @@ static int init_event_table(void) {
     }
 
     /* Enumeration info (drm render/card, hsa/hip ids) */
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
     if (amdsmi_get_gpu_enumeration_info_p) {
       amdsmi_enumeration_info_t einfo;
       if (amdsmi_get_gpu_enumeration_info_p(device_handles[d], &einfo) == AMDSMI_STATUS_SUCCESS) {
@@ -2317,6 +2322,7 @@ static int init_event_table(void) {
         idx++;
       }
     }
+#endif /* AMDSMI_HAVE_ENUMERATION_INFO */
     /* ASIC info (numeric IDs & CU count) */
     if (amdsmi_get_gpu_asic_info_p) {
       amdsmi_asic_info_t ainfo;

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -122,6 +122,7 @@ int access_amdsmi_gpu_string_hash(int mode, void *arg) {
   event->value = (int64_t)_str_to_u64_hash(buf);
   return PAPI_OK;
 }
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
 int access_amdsmi_enumeration_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
@@ -152,6 +153,7 @@ int access_amdsmi_enumeration_info(int mode, void *arg) {
   }
   return PAPI_OK;
 }
+#endif
 int access_amdsmi_asic_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -6,6 +6,13 @@
 #include <amd_smi/amdsmi.h>
 #include <stdint.h>
 
+/* Some older AMD SMI releases do not expose amdsmi_enumeration_info_t or the
+ * associated query function.  Guard all related uses behind
+ * AMDSMI_HAVE_ENUMERATION_INFO so the component can still build when using
+ * those older headers.  Define AMDSMI_HAVE_ENUMERATION_INFO externally if the
+ * enumeration APIs are available.
+ */
+
 /* Mode enumeration used by accessors */
 typedef enum {
   PAPI_MODE_READ = 1,
@@ -73,7 +80,9 @@ extern amdsmi_status_t (*amdsmi_get_gpu_board_info_p)(amdsmi_processor_handle, a
 extern amdsmi_status_t (*amdsmi_get_fw_info_p)(amdsmi_processor_handle, amdsmi_fw_info_t *);
 extern amdsmi_status_t (*amdsmi_get_gpu_vbios_info_p)(amdsmi_processor_handle, amdsmi_vbios_info_t *);
 extern amdsmi_status_t (*amdsmi_get_gpu_device_uuid_p)(amdsmi_processor_handle, unsigned int *, char *);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
 extern amdsmi_status_t (*amdsmi_get_gpu_enumeration_info_p)(amdsmi_processor_handle, amdsmi_enumeration_info_t *);
+#endif
 extern amdsmi_status_t (*amdsmi_get_gpu_vendor_name_p)(amdsmi_processor_handle, char *, size_t);
 extern amdsmi_status_t (*amdsmi_get_gpu_vram_vendor_p)(amdsmi_processor_handle, char *, uint32_t);
 extern amdsmi_status_t (*amdsmi_get_gpu_subsystem_name_p)(amdsmi_processor_handle, char *, size_t);
@@ -153,11 +162,13 @@ int access_amdsmi_energy_count(int mode, void *arg);
 int access_amdsmi_power_profile_status(int mode, void *arg);
 int access_amdsmi_uuid_hash(int mode, void *arg);
 int access_amdsmi_gpu_string_hash(int mode, void *arg);
-int access_amdsmi_enumeration_info(int mode, void *arg);
 int access_amdsmi_asic_info(int mode, void *arg);
 int access_amdsmi_link_metrics(int mode, void *arg);
 int access_amdsmi_process_count(int mode, void *arg);
 int access_amdsmi_ecc_total(int mode, void *arg);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
+int access_amdsmi_enumeration_info(int mode, void *arg);
+#endif
 int access_amdsmi_ecc_enabled_mask(int mode, void *arg);
 int access_amdsmi_compute_partition_hash(int mode, void *arg);
 int access_amdsmi_memory_partition_hash(int mode, void *arg);


### PR DESCRIPTION
## Summary
- guard AMD SMI enumeration API usage behind `AMDSMI_HAVE_ENUMERATION_INFO`
- allow building the amd_smi component with older AMD SMI headers lacking enumeration support

## Testing
- `make -C src components/amd_smi/amds.o` *(fails: amd_smi/amdsmi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3867bca50832b8a7972166666f63d