### PR TITLE
Guard AMD SMI enumeration info usage for older libraries

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -48,7 +48,9 @@ static amdsmi_status_t (*amdsmi_get_gpu_board_info_p)(amdsmi_processor_handle, a
 static amdsmi_status_t (*amdsmi_get_fw_info_p)(amdsmi_processor_handle, amdsmi_fw_info_t *);
 static amdsmi_status_t (*amdsmi_get_gpu_vbios_info_p)(amdsmi_processor_handle, amdsmi_vbios_info_t *);
 static amdsmi_status_t (*amdsmi_get_gpu_device_uuid_p)(amdsmi_processor_handle, unsigned int *, char *);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
 static amdsmi_status_t (*amdsmi_get_gpu_enumeration_info_p)(amdsmi_processor_handle, amdsmi_enumeration_info_t *);
+#endif
 static amdsmi_status_t (*amdsmi_get_gpu_vendor_name_p)(amdsmi_processor_handle, char *, size_t);
 static amdsmi_status_t (*amdsmi_get_gpu_vram_vendor_p)(amdsmi_processor_handle, char *, uint32_t);
 static amdsmi_status_t (*amdsmi_get_gpu_subsystem_name_p)(amdsmi_processor_handle, char *, size_t);
@@ -186,7 +188,9 @@ static int access_amdsmi_power_profile_status(int mode, void *arg);
 static uint64_t _str_to_u64_hash(const char *s);
 static int access_amdsmi_uuid_hash(int mode, void *arg);
 static int access_amdsmi_gpu_string_hash(int mode, void *arg);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
 static int access_amdsmi_enumeration_info(int mode, void *arg);
+#endif
 static int access_amdsmi_asic_info(int mode, void *arg);
 static int access_amdsmi_link_metrics(int mode, void *arg);
 static int access_amdsmi_process_count(int mode, void *arg);
@@ -202,7 +206,9 @@ static int access_amdsmi_lib_version(int mode, void *arg);
 static uint64_t _str_to_u64_hash(const char *s);
 static int access_amdsmi_uuid_hash(int mode, void *arg);
 static int access_amdsmi_gpu_string_hash(int mode, void *arg);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
 static int access_amdsmi_enumeration_info(int mode, void *arg);
+#endif
 static int access_amdsmi_asic_info(int mode, void *arg);
 static int access_amdsmi_link_metrics(int mode, void *arg);
 static int access_amdsmi_process_count(int mode, void *arg);
@@ -312,7 +318,9 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_fw_info_p = sym("amdsmi_get_fw_info", NULL);
   amdsmi_get_gpu_vbios_info_p = sym("amdsmi_get_gpu_vbios_info", NULL);
   amdsmi_get_gpu_device_uuid_p = sym("amdsmi_get_gpu_device_uuid", NULL);
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
   amdsmi_get_gpu_enumeration_info_p = sym("amdsmi_get_gpu_enumeration_info", NULL);
+#endif
   amdsmi_get_gpu_vendor_name_p = sym("amdsmi_get_gpu_vendor_name", NULL);
   amdsmi_get_gpu_vram_vendor_p = sym("amdsmi_get_gpu_vram_vendor", NULL);
   amdsmi_get_gpu_subsystem_name_p = sym("amdsmi_get_gpu_subsystem_name", NULL);
@@ -2163,6 +2171,7 @@ static int init_event_table(void) {
     }
 
     /* Enumeration info (drm render/card, hsa/hip ids) */
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
     if (amdsmi_get_gpu_enumeration_info_p) {
       amdsmi_enumeration_info_t einfo;
       if (amdsmi_get_gpu_enumeration_info_p(device_handles[d], &einfo) == AMDSMI_STATUS_SUCCESS) {
@@ -2256,6 +2265,7 @@ static int init_event_table(void) {
         idx++;
       }
     }
+#endif
     /* ASIC info (numeric IDs & CU count) */
     if (amdsmi_get_gpu_asic_info_p) {
       amdsmi_asic_info_t ainfo;
@@ -2918,6 +2928,7 @@ static int access_amdsmi_gpu_string_hash(int mode, void *arg) {
   event->value = (int64_t)_str_to_u64_hash(buf);
   return PAPI_OK;
 }
+#ifdef AMDSMI_HAVE_ENUMERATION_INFO
 static int access_amdsmi_enumeration_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
@@ -2948,6 +2959,7 @@ static int access_amdsmi_enumeration_info(int mode, void *arg) {
   }
   return PAPI_OK;
 }
+#endif
 static int access_amdsmi_asic_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;


### PR DESCRIPTION
## Summary
- guard amdsmi enumeration info references with `AMDSMI_HAVE_ENUMERATION_INFO`

## Testing
- `gcc -Isrc/components/amd_smi -c src/components/amd_smi/amds.c -o /tmp/amds.o` *(fails: amdsmi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a67e315c832b9130d20c54b5a9b4