### PR TITLE
Gate AMD SMI metrics by library version

### DIFF
--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -131,10 +131,11 @@ int access_amdsmi_gpu_string_hash(int mode, void *arg) {
   event->value = (int64_t)_str_to_u64_hash(buf);
   return PAPI_OK;
 }
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_enumeration_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!amdsmi_get_gpu_enumeration_info_p)
+  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_enumeration_info_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles[event->device])
@@ -161,6 +162,7 @@ int access_amdsmi_enumeration_info(int mode, void *arg) {
   }
   return PAPI_OK;
 }
+#endif
 int access_amdsmi_asic_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
@@ -754,7 +756,10 @@ int access_amdsmi_gpu_info(int mode, void *arg) {
     }
     break;
   }
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   case 4: {
+    if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_virtualization_mode_p)
+      return PAPI_ENOSUPP;
     amdsmi_virtualization_mode_t mode_val;
     status = amdsmi_get_gpu_virtualization_mode_p(device_handles[event->device], &mode_val);
     if (status == AMDSMI_STATUS_SUCCESS) {
@@ -762,6 +767,7 @@ int access_amdsmi_gpu_info(int mode, void *arg) {
     }
     break;
   }
+#endif
   case 5: {
     int32_t numa_node = -1;
     status = amdsmi_get_gpu_topo_numa_affinity_p(device_handles[event->device], &numa_node);
@@ -1831,10 +1837,11 @@ int access_amdsmi_fw_version(int mode, void *arg) {
   return PAPI_EMISC;
 }
 
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!amdsmi_get_gpu_vram_info_p)
+  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_vram_info_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles[event->device])
@@ -1846,6 +1853,7 @@ int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   event->value = (int64_t)info.vram_max_bandwidth; /* GB/s */
   return PAPI_OK;
 }
+#endif
 
 int access_amdsmi_bad_page_count(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
@@ -1938,9 +1946,13 @@ int access_amdsmi_power_sensor(int mode, void *arg) {
   case 1:
     event->value = (int64_t)info.average_socket_power;
     break;
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   case 2:
+    if (amdsmi_lib_major < 25)
+      return PAPI_ENOSUPP;
     event->value = (int64_t)info.socket_power;
     break;
+#endif
   case 3:
     event->value = (int64_t)info.gfx_voltage;
     break;
@@ -1984,9 +1996,13 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
   case 3:
     event->value = (int64_t)info.pcie_static.slot_type;
     break;
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   case 4:
+    if (amdsmi_lib_major < 25)
+      return PAPI_ENOSUPP;
     event->value = (int64_t)info.pcie_static.max_pcie_interface_version;
     break;
+#endif
   case 5:
     event->value = info.pcie_metric.pcie_width;
     break;

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -1430,7 +1430,7 @@ int access_amdsmi_pm_metrics_count(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!amdsmi_get_gpu_pm_metrics_info_p)
+  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_pm_metrics_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_name_value_t *metrics = NULL;
@@ -1451,7 +1451,7 @@ int access_amdsmi_pm_metric_value(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!amdsmi_get_gpu_pm_metrics_info_p)
+  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_pm_metrics_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_name_value_t *metrics = NULL;
@@ -1529,7 +1529,7 @@ int access_amdsmi_reg_count(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!amdsmi_get_gpu_reg_table_info_p)
+  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_reg_table_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_reg_type_t reg_type = (amdsmi_reg_type_t)event->variant; /* set at registration */
@@ -1551,7 +1551,7 @@ int access_amdsmi_reg_value(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!amdsmi_get_gpu_reg_table_info_p)
+  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_reg_table_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_reg_type_t reg_type = (amdsmi_reg_type_t)event->variant;

--- a/src/components/amd_smi/amds_funcs.h
+++ b/src/components/amd_smi/amds_funcs.h
@@ -1,7 +1,7 @@
 #ifndef AMDS_FUNCS_H
 #define AMDS_FUNCS_H
 
-#define AMD_SMI_GPU_FUNCTIONS(_)                                               \
+#define AMD_SMI_GPU_FUNCTIONS_BASE(_)                                          \
   _(amdsmi_init_p, amdsmi_status_t, (uint64_t))                                \
   _(amdsmi_shut_down_p, amdsmi_status_t, (void))                               \
   _(amdsmi_get_socket_handles_p, amdsmi_status_t,                              \
@@ -55,8 +55,6 @@
     (amdsmi_processor_handle, amdsmi_vbios_info_t *))                          \
   _(amdsmi_get_gpu_device_uuid_p, amdsmi_status_t,                             \
     (amdsmi_processor_handle, unsigned int *, char *))                         \
-  _(amdsmi_get_gpu_enumeration_info_p, amdsmi_status_t,                        \
-    (amdsmi_processor_handle, amdsmi_enumeration_info_t *))                    \
   _(amdsmi_get_gpu_vendor_name_p, amdsmi_status_t,                             \
     (amdsmi_processor_handle, char *, size_t))                                 \
   _(amdsmi_get_gpu_vram_vendor_p, amdsmi_status_t,                             \
@@ -88,8 +86,6 @@
     (amdsmi_processor_handle, uint16_t *))                                     \
   _(amdsmi_get_gpu_subsystem_id_p, amdsmi_status_t,                            \
     (amdsmi_processor_handle, uint16_t *))                                     \
-  _(amdsmi_get_gpu_virtualization_mode_p, amdsmi_status_t,                     \
-    (amdsmi_processor_handle, amdsmi_virtualization_mode_t *))                 \
   _(amdsmi_get_gpu_process_isolation_p, amdsmi_status_t,                       \
     (amdsmi_processor_handle, uint32_t *))                                     \
   _(amdsmi_get_gpu_xcd_counter_p, amdsmi_status_t,                             \
@@ -155,6 +151,17 @@
     (int, uint32_t *, amdsmi_evt_notification_data_t *))                       \
   _(amdsmi_stop_gpu_event_notification_p, amdsmi_status_t,                     \
     (amdsmi_processor_handle))
+
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#define AMD_SMI_GPU_FUNCTIONS(_)                                              \
+  AMD_SMI_GPU_FUNCTIONS_BASE(_)                                              \
+  _(amdsmi_get_gpu_enumeration_info_p, amdsmi_status_t,                       \
+    (amdsmi_processor_handle, amdsmi_enumeration_info_t *))                   \
+  _(amdsmi_get_gpu_virtualization_mode_p, amdsmi_status_t,                    \
+    (amdsmi_processor_handle, amdsmi_virtualization_mode_t *))
+#else
+#define AMD_SMI_GPU_FUNCTIONS(_) AMD_SMI_GPU_FUNCTIONS_BASE(_)
+#endif
 
 #define AMD_SMI_CPU_FUNCTIONS(_)                                               \
   _(amdsmi_get_cpu_handles_p, amdsmi_status_t,                                 \

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -45,6 +45,7 @@ void *amds_get_htable(void);
 native_event_table_t *amds_get_ntv_table(void);
 unsigned int amds_get_lock(void);
 void amds_set_lock(unsigned int lock);
+uint32_t amds_get_lib_major(void);
 
 #ifndef AMDS_PRIV_IMPL
 #define device_handles (amds_get_device_handles())
@@ -55,6 +56,7 @@ void amds_set_lock(unsigned int lock);
 #define cores_per_socket (amds_get_cores_per_socket())
 #define htable (amds_get_htable())
 #define ntv_table_p (amds_get_ntv_table())
+#define amdsmi_lib_major (amds_get_lib_major())
 #endif
 
 /* AMD SMI function pointers */

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -6,6 +6,10 @@
 #include <amd_smi/amdsmi.h>
 #include <stdint.h>
 
+#ifndef AMDSMI_LIB_VERSION_MAJOR
+#define AMDSMI_LIB_VERSION_MAJOR 0
+#endif
+
 /* Mode enumeration used by accessors */
 typedef enum {
   PAPI_MODE_READ = 1,
@@ -89,7 +93,9 @@ int access_amdsmi_energy_count(int mode, void *arg);
 int access_amdsmi_power_profile_status(int mode, void *arg);
 int access_amdsmi_uuid_hash(int mode, void *arg);
 int access_amdsmi_gpu_string_hash(int mode, void *arg);
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_enumeration_info(int mode, void *arg);
+#endif
 int access_amdsmi_asic_info(int mode, void *arg);
 int access_amdsmi_link_metrics(int mode, void *arg);
 int access_amdsmi_process_info(int mode, void *arg);
@@ -128,7 +134,9 @@ int access_amdsmi_xgmi_plpd_supported(int mode, void *arg);
 int access_amdsmi_process_isolation(int mode, void *arg);
 int access_amdsmi_xcd_counter(int mode, void *arg);
 int access_amdsmi_board_serial_hash(int mode, void *arg);
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
+#endif
 int access_amdsmi_fw_version(int mode, void *arg);
 int access_amdsmi_bad_page_count(int mode, void *arg);
 int access_amdsmi_bad_page_threshold(int mode, void *arg);


### PR DESCRIPTION
## Summary
- Track AMD SMI library major version during initialization
- Only expose PM metrics and register table events when using libamdsmi v25+
- Guard accessors for these events with the same version check

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aebce690832b98e93de7bc2971c2