### PR TITLE
Harden AMD SMI tests against stray TESTS_QUIET values

### DIFF
--- a/src/components/amd_smi/tests/runtest.sh
+++ b/src/components/amd_smi/tests/runtest.sh
@@ -36,7 +36,8 @@ for arg in "$@"; do
     --print-only=*) PRINT_SET="${arg#*=}" ;;
     --hello-event=*) HELLO_EVENT="${arg#*=}" ;;
     -h|--help)     usage; exit 0 ;;
-    *) echo "Unknown option: $arg"; usage; exit 2 ;;
+    --*) echo "Unknown option: $arg"; usage; exit 2 ;;
+    *) ;;                         # ignore any other stray args
   esac
 done
 

--- a/src/components/amd_smi/tests/test_harness.hpp
+++ b/src/components/amd_smi/tests/test_harness.hpp
@@ -18,12 +18,30 @@ static HarnessOpts harness_opts;
 //  - remove it from argv so it can't be mistaken for a positional arg,
 //  - enable quiet mode via env for the harness to pick up.
 static inline void harness_accept_tests_quiet(int *argc, char **argv) {
+    /* The PAPI test harness historically invokes each test with a single
+       positional token holding the value of the TESTS_QUIET environment
+       variable.  Only the literal string "TESTS_QUIET" should trigger quiet
+       mode.  If any other value is present we drop it from argv and ignore
+       the environment variable so tests don't misinterpret it as a positional
+       argument. */
+
+    const char *badarg = NULL;
+    const char *tq_env = getenv("TESTS_QUIET");
+    if (tq_env && strcmp(tq_env, "TESTS_QUIET") != 0) {
+        badarg = tq_env;          // remember stray value to filter from argv
+        unsetenv("TESTS_QUIET");  // ignore non‑literal TESTS_QUIET
+    }
+
     int w = 1;
     int saw_quiet = 0;
     for (int r = 1; r < *argc; ++r) {
         const char *a = argv[r];
         if (a && (!strcmp(a, "TESTS_QUIET") || !strcmp(a, "QUIET"))) {
             saw_quiet = 1;
+            continue;
+        }
+        if (badarg && a && strcmp(a, badarg) == 0) {
+            /* discard unexpected TESTS_QUIET value */
             continue;
         }
         argv[w++] = argv[r];


### PR DESCRIPTION
## Summary
- Ignore non-literal TESTS_QUIET values in AMD SMI test harness
- Tolerate stray arguments in AMD SMI runtest.sh

## Testing
- `bash -n src/components/amd_smi/tests/runtest.sh`
- `TESTS_QUIET=foo src/components/amd_smi/tests/runtest.sh foo`
- `g++ -c src/components/amd_smi/tests/amdsmi_hello.cpp -I src -I src/components/amd_smi/tests -std=c++11 -o /tmp/amdsmi_hello.o`


------
https://chatgpt.com/codex/tasks/task_e_68c0747807d0832baee73120640e0aa6