### PR TITLE
Guard AMD SMI 6.3-only APIs for older ROCm builds

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -2319,7 +2319,8 @@ static int init_event_table(void) {
       }
     }
 
-    if (amdsmi_get_gpu_vram_info_p) {
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+    if (amdsmi_get_gpu_vram_info_p && amds_lib_version_at_least(25, 0)) {
       amdsmi_vram_info_t vinfo;
       if (amdsmi_get_gpu_vram_info_p(device_handles[d], &vinfo) ==
           AMDSMI_STATUS_SUCCESS) {
@@ -2333,6 +2334,7 @@ static int init_event_table(void) {
           return PAPI_ENOMEM;
       }
     }
+#endif
 
     if (amdsmi_get_gpu_memory_reserved_pages_p) {
       uint32_t nump = 0;

--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -267,7 +267,7 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_energy_count_p = sym("amdsmi_get_energy_count", NULL);
   amdsmi_get_gpu_power_profile_presets_p =
       sym("amdsmi_get_gpu_power_profile_presets", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
   // AMD SMI 24.7+ optional queries
   amdsmi_get_violation_status_p = sym("amdsmi_get_violation_status", NULL);
   amdsmi_get_gpu_accelerator_partition_profile_p =
@@ -929,7 +929,7 @@ static int init_event_table(void) {
                       access_amdsmi_pcie_info) != PAPI_OK)
           return PAPI_ENOMEM;
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
         if (amds_lib_version_at_least(24, 7)) {
           CHECK_EVENT_IDX(idx);
           snprintf(name_buf, sizeof(name_buf),
@@ -2098,7 +2098,7 @@ static int init_event_table(void) {
         }
       }
     }
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
     if (amdsmi_get_gpu_kfd_info_p) {
       amdsmi_kfd_info_t kinfo;
       if (amdsmi_get_gpu_kfd_info_p(device_handles[d], &kinfo) ==
@@ -2320,22 +2320,18 @@ static int init_event_table(void) {
     }
 
     if (amdsmi_get_gpu_vram_info_p) {
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-      if (amds_lib_version_at_least(24, 7)) {
-        amdsmi_vram_info_t vinfo;
-        if (amdsmi_get_gpu_vram_info_p(device_handles[d], &vinfo) ==
-            AMDSMI_STATUS_SUCCESS) {
-          CHECK_EVENT_IDX(idx);
-          snprintf(name_buf, sizeof(name_buf),
-                   "vram_max_bandwidth:device=%d", d);
-          snprintf(descr_buf, sizeof(descr_buf),
-                   "Device %d VRAM max bandwidth (GB/s)", d);
-          if (add_event(&idx, name_buf, descr_buf, d, 0, 0, PAPI_MODE_READ,
-                        access_amdsmi_vram_max_bandwidth) != PAPI_OK)
-            return PAPI_ENOMEM;
-        }
+      amdsmi_vram_info_t vinfo;
+      if (amdsmi_get_gpu_vram_info_p(device_handles[d], &vinfo) ==
+          AMDSMI_STATUS_SUCCESS) {
+        CHECK_EVENT_IDX(idx);
+        snprintf(name_buf, sizeof(name_buf),
+                 "vram_max_bandwidth:device=%d", d);
+        snprintf(descr_buf, sizeof(descr_buf),
+                 "Device %d VRAM max bandwidth (GB/s)", d);
+        if (add_event(&idx, name_buf, descr_buf, d, 0, 0, PAPI_MODE_READ,
+                      access_amdsmi_vram_max_bandwidth) != PAPI_OK)
+          return PAPI_ENOMEM;
       }
-#endif
     }
 
     if (amdsmi_get_gpu_memory_reserved_pages_p) {
@@ -2436,7 +2432,7 @@ static int init_event_table(void) {
           return PAPI_ENOMEM;
 
         /* Register socket power in microwatts */
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
         if (amds_lib_version_at_least(24, 7)) {
           CHECK_EVENT_IDX(idx);
           snprintf(name_buf, sizeof(name_buf),
@@ -2681,7 +2677,7 @@ static int init_event_table(void) {
                   access_amdsmi_power_profile_status) != PAPI_OK)
       return PAPI_ENOMEM;
   }
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
   /* GPU violation status metrics */
   if (amdsmi_get_violation_status_p) {
     for (int d = 0; d < gpu_count; ++d) {
@@ -3429,7 +3425,7 @@ static int init_event_table(void) {
           return PAPI_ENOMEM;
       }
     }
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
     if (amdsmi_get_link_topology_nearest_p) {
       amdsmi_link_type_t lt_types[] = {AMDSMI_LINK_TYPE_XGMI,
                                        AMDSMI_LINK_TYPE_PCIE};

--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -265,8 +265,10 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_energy_count_p = sym("amdsmi_get_energy_count", NULL);
   amdsmi_get_gpu_power_profile_presets_p =
       sym("amdsmi_get_gpu_power_profile_presets", NULL);
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   amdsmi_get_violation_status_p =
       sym("amdsmi_get_violation_status", NULL);
+#endif
   // Additional read-only queries
   amdsmi_get_lib_version_p = sym("amdsmi_get_lib_version", NULL);
   amdsmi_get_gpu_driver_info_p = sym("amdsmi_get_gpu_driver_info", NULL);
@@ -288,10 +290,14 @@ static int load_amdsmi_sym(void) {
       sym("amdsmi_topo_get_numa_node_number", NULL);
   amdsmi_topo_get_link_weight_p = sym("amdsmi_topo_get_link_weight", NULL);
   amdsmi_topo_get_link_type_p = sym("amdsmi_topo_get_link_type", NULL);
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   amdsmi_topo_get_p2p_status_p = sym("amdsmi_topo_get_p2p_status", NULL);
+#endif
   amdsmi_is_P2P_accessible_p = sym("amdsmi_is_P2P_accessible", NULL);
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   amdsmi_get_link_topology_nearest_p =
       sym("amdsmi_get_link_topology_nearest", NULL);
+#endif
   amdsmi_get_gpu_device_bdf_p = sym("amdsmi_get_gpu_device_bdf", NULL);
   amdsmi_get_gpu_ecc_enabled_p = sym("amdsmi_get_gpu_ecc_enabled", NULL);
   amdsmi_get_gpu_total_ecc_count_p =
@@ -310,7 +316,9 @@ static int load_amdsmi_sym(void) {
       sym("amdsmi_is_gpu_memory_partition_supported", NULL);
   amdsmi_get_gpu_memory_reserved_pages_p =
       sym("amdsmi_get_gpu_memory_reserved_pages", NULL);
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   amdsmi_get_gpu_kfd_info_p = sym("amdsmi_get_gpu_kfd_info", NULL);
+#endif
   amdsmi_get_gpu_metrics_header_info_p =
         sym("amdsmi_get_gpu_metrics_header_info", NULL);
 #if AMDSMI_LIB_VERSION_MAJOR >= 25
@@ -320,8 +328,10 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_xgmi_info_p = sym("amdsmi_get_xgmi_info", NULL);
   amdsmi_gpu_xgmi_error_status_p =
       sym("amdsmi_gpu_xgmi_error_status", NULL);
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   amdsmi_get_gpu_accelerator_partition_profile_p =
       sym("amdsmi_get_gpu_accelerator_partition_profile", NULL);
+#endif
   amdsmi_get_gpu_cache_info_p = sym("amdsmi_get_gpu_cache_info", NULL);
   amdsmi_get_gpu_mem_overdrive_level_p =
       sym("amdsmi_get_gpu_mem_overdrive_level", NULL);
@@ -1923,6 +1933,7 @@ static int init_event_table(void) {
                       access_amdsmi_utilization_count) != PAPI_OK)
           return PAPI_ENOMEM;
       }
+#ifdef AMDSMI_COARSE_DECODER_ACTIVITY
       uc.type = AMDSMI_COARSE_DECODER_ACTIVITY;
       if (amdsmi_get_utilization_count_p(device_handles[d], &uc, 1, &ts) ==
           AMDSMI_STATUS_SUCCESS) {
@@ -1936,6 +1947,7 @@ static int init_event_table(void) {
                       access_amdsmi_utilization_count) != PAPI_OK)
           return PAPI_ENOMEM;
       }
+#endif
     }
   }
   /* GPU clock frequency levels for multiple clock domains */
@@ -2091,6 +2103,7 @@ static int init_event_table(void) {
         }
       }
     }
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
     if (amdsmi_get_gpu_kfd_info_p) {
       amdsmi_kfd_info_t kinfo;
       if (amdsmi_get_gpu_kfd_info_p(device_handles[d], &kinfo) ==
@@ -2110,6 +2123,7 @@ static int init_event_table(void) {
         }
       }
     }
+#endif
     // NUMA node via topology API
     if (amdsmi_topo_get_numa_node_number_p) {
       uint32_t node;
@@ -2672,6 +2686,7 @@ static int init_event_table(void) {
                   access_amdsmi_power_profile_status) != PAPI_OK)
       return PAPI_ENOMEM;
   }
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   /* GPU violation status metrics */
   if (amdsmi_get_violation_status_p) {
     for (int d = 0; d < gpu_count; ++d) {
@@ -2705,6 +2720,7 @@ static int init_event_table(void) {
       }
     }
   }
+#endif
 #ifndef AMDSMI_DISABLE_ESMI
   /* CPU metrics events */
   if (cpu_count > 0) {
@@ -3417,6 +3433,7 @@ static int init_event_table(void) {
           return PAPI_ENOMEM;
       }
     }
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
     if (amdsmi_get_link_topology_nearest_p) {
       amdsmi_link_type_t lt_types[] = {AMDSMI_LINK_TYPE_XGMI,
                                        AMDSMI_LINK_TYPE_PCIE};
@@ -3438,6 +3455,7 @@ static int init_event_table(void) {
         }
       }
     }
+#endif
     for (int p = 0; p < gpu_count; ++p) {
       if (p == d)
         continue;

--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -257,10 +257,6 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_gpu_id_p = sym("amdsmi_get_gpu_id", NULL);
   amdsmi_get_gpu_revision_p = sym("amdsmi_get_gpu_revision", NULL);
   amdsmi_get_gpu_subsystem_id_p = sym("amdsmi_get_gpu_subsystem_id", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-  amdsmi_get_gpu_virtualization_mode_p =
-      sym("amdsmi_get_gpu_virtualization_mode", NULL);
-#endif
   amdsmi_get_gpu_process_isolation_p =
       sym("amdsmi_get_gpu_process_isolation", NULL);
   amdsmi_get_gpu_xcd_counter_p = sym("amdsmi_get_gpu_xcd_counter", NULL);
@@ -272,8 +268,25 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_gpu_power_profile_presets_p =
       sym("amdsmi_get_gpu_power_profile_presets", NULL);
 #if AMDSMI_VERSION_AT_LEAST(24, 7)
-  amdsmi_get_violation_status_p =
-      sym("amdsmi_get_violation_status", NULL);
+  // AMD SMI 24.7+ optional queries
+  amdsmi_get_violation_status_p = sym("amdsmi_get_violation_status", NULL);
+  amdsmi_get_gpu_accelerator_partition_profile_p =
+      sym("amdsmi_get_gpu_accelerator_partition_profile", NULL);
+  amdsmi_topo_get_p2p_status_p = sym("amdsmi_topo_get_p2p_status", NULL);
+  amdsmi_get_link_topology_nearest_p =
+      sym("amdsmi_get_link_topology_nearest", NULL);
+  amdsmi_get_gpu_kfd_info_p = sym("amdsmi_get_gpu_kfd_info", NULL);
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+  // AMD SMI 25.0+ optional queries
+  amdsmi_get_gpu_virtualization_mode_p =
+      sym("amdsmi_get_gpu_virtualization_mode", NULL);
+  amdsmi_get_gpu_enumeration_info_p =
+      sym("amdsmi_get_gpu_enumeration_info", NULL);
+  amdsmi_get_gpu_memory_partition_config_p =
+      sym("amdsmi_get_gpu_memory_partition_config", NULL);
+  amdsmi_get_gpu_xgmi_link_status_p =
+      sym("amdsmi_get_gpu_xgmi_link_status", NULL);
+#endif
 #endif
   // Additional read-only queries
   amdsmi_get_lib_version_p = sym("amdsmi_get_lib_version", NULL);
@@ -283,10 +296,6 @@ static int load_amdsmi_sym(void) {
   amdsmi_get_fw_info_p = sym("amdsmi_get_fw_info", NULL);
   amdsmi_get_gpu_vbios_info_p = sym("amdsmi_get_gpu_vbios_info", NULL);
   amdsmi_get_gpu_device_uuid_p = sym("amdsmi_get_gpu_device_uuid", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-  amdsmi_get_gpu_enumeration_info_p =
-      sym("amdsmi_get_gpu_enumeration_info", NULL);
-#endif
   amdsmi_get_gpu_vendor_name_p = sym("amdsmi_get_gpu_vendor_name", NULL);
   amdsmi_get_gpu_vram_vendor_p = sym("amdsmi_get_gpu_vram_vendor", NULL);
   amdsmi_get_gpu_subsystem_name_p = sym("amdsmi_get_gpu_subsystem_name", NULL);
@@ -296,14 +305,8 @@ static int load_amdsmi_sym(void) {
       sym("amdsmi_topo_get_numa_node_number", NULL);
   amdsmi_topo_get_link_weight_p = sym("amdsmi_topo_get_link_weight", NULL);
   amdsmi_topo_get_link_type_p = sym("amdsmi_topo_get_link_type", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-  amdsmi_topo_get_p2p_status_p = sym("amdsmi_topo_get_p2p_status", NULL);
-#endif
   amdsmi_is_P2P_accessible_p = sym("amdsmi_is_P2P_accessible", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-  amdsmi_get_link_topology_nearest_p =
-      sym("amdsmi_get_link_topology_nearest", NULL);
-#endif
+
   amdsmi_get_gpu_device_bdf_p = sym("amdsmi_get_gpu_device_bdf", NULL);
   amdsmi_get_gpu_ecc_enabled_p = sym("amdsmi_get_gpu_ecc_enabled", NULL);
   amdsmi_get_gpu_total_ecc_count_p =
@@ -314,30 +317,15 @@ static int load_amdsmi_sym(void) {
       sym("amdsmi_get_gpu_compute_partition", NULL);
   amdsmi_get_gpu_memory_partition_p =
         sym("amdsmi_get_gpu_memory_partition", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-    amdsmi_get_gpu_memory_partition_config_p =
-        sym("amdsmi_get_gpu_memory_partition_config", NULL);
-#endif
   amdsmi_is_gpu_memory_partition_supported_p =
       sym("amdsmi_is_gpu_memory_partition_supported", NULL);
   amdsmi_get_gpu_memory_reserved_pages_p =
       sym("amdsmi_get_gpu_memory_reserved_pages", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-  amdsmi_get_gpu_kfd_info_p = sym("amdsmi_get_gpu_kfd_info", NULL);
-#endif
   amdsmi_get_gpu_metrics_header_info_p =
         sym("amdsmi_get_gpu_metrics_header_info", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-    amdsmi_get_gpu_xgmi_link_status_p =
-        sym("amdsmi_get_gpu_xgmi_link_status", NULL);
-#endif
   amdsmi_get_xgmi_info_p = sym("amdsmi_get_xgmi_info", NULL);
   amdsmi_gpu_xgmi_error_status_p =
       sym("amdsmi_gpu_xgmi_error_status", NULL);
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-  amdsmi_get_gpu_accelerator_partition_profile_p =
-      sym("amdsmi_get_gpu_accelerator_partition_profile", NULL);
-#endif
   amdsmi_get_gpu_cache_info_p = sym("amdsmi_get_gpu_cache_info", NULL);
   amdsmi_get_gpu_mem_overdrive_level_p =
       sym("amdsmi_get_gpu_mem_overdrive_level", NULL);
@@ -2146,9 +2134,9 @@ static int init_event_table(void) {
       }
     }
     // GPU Virtualization Mode
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
     amdsmi_virtualization_mode_t vmode;
-    if (amds_lib_version_at_least(24, 7) && amdsmi_get_gpu_virtualization_mode_p &&
+    if (amds_lib_version_at_least(25, 0) && amdsmi_get_gpu_virtualization_mode_p &&
         amdsmi_get_gpu_virtualization_mode_p(device_handles[d], &vmode) ==
             AMDSMI_STATUS_SUCCESS) {
       snprintf(name_buf, sizeof(name_buf), "gpu_virtualization_mode:device=%d",
@@ -3191,8 +3179,8 @@ static int init_event_table(void) {
     }
 
     /* Enumeration info (drm render/card, hsa/hip ids) */
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-    if (amds_lib_version_at_least(24, 7) && amdsmi_get_gpu_enumeration_info_p) {
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+    if (amds_lib_version_at_least(25, 0) && amdsmi_get_gpu_enumeration_info_p) {
       amdsmi_enumeration_info_t einfo;
       if (amdsmi_get_gpu_enumeration_info_p(device_handles[d], &einfo) ==
           AMDSMI_STATUS_SUCCESS) {
@@ -3305,8 +3293,9 @@ static int init_event_table(void) {
       }
     }
     /*
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-    if (amdsmi_get_gpu_memory_partition_config_p) {
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+    if (amds_lib_version_at_least(25, 0) &&
+        amdsmi_get_gpu_memory_partition_config_p) {
       amdsmi_memory_partition_config_t cfg = {0};
       // Probe memory partition configuration 
       if (amdsmi_get_gpu_memory_partition_config_p(device_handles[d], &cfg) ==
@@ -3407,8 +3396,8 @@ static int init_event_table(void) {
         }
       }
     }
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
-    if (amdsmi_get_gpu_xgmi_link_status_p) {
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+    if (amds_lib_version_at_least(25, 0) && amdsmi_get_gpu_xgmi_link_status_p) {
       amdsmi_xgmi_link_status_t st;
       if (amdsmi_get_gpu_xgmi_link_status_p(device_handles[d], &st) ==
           AMDSMI_STATUS_SUCCESS) {

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -197,9 +197,14 @@ int access_amdsmi_asic_info(int mode, void *arg) {
   case 4:
     event->value = (int64_t)info.rev_id;
     break;
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   case 5:
     event->value = (int64_t)info.num_of_compute_units;
     break;
+#else
+  case 5:
+    return PAPI_ENOSUPP;
+#endif
   default:
     return PAPI_EMISC;
   }
@@ -360,6 +365,7 @@ int access_amdsmi_link_type(int mode, void *arg) {
   return PAPI_OK;
 }
 
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_p2p_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_topo_get_p2p_status_p)
     return PAPI_ENOSUPP;
@@ -416,6 +422,7 @@ int access_amdsmi_p2p_status(int mode, void *arg) {
   return PAPI_OK;
 }
 
+#endif
 
 int access_amdsmi_p2p_accessible(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_is_P2P_accessible_p)
@@ -434,6 +441,7 @@ int access_amdsmi_p2p_accessible(int mode, void *arg) {
   return PAPI_OK;
 }
 
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_link_topology_nearest(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_link_topology_nearest_p)
     return PAPI_ENOSUPP;
@@ -450,6 +458,7 @@ int access_amdsmi_link_topology_nearest(int mode, void *arg) {
   event->value = (int64_t)info.count;
   return PAPI_OK;
 }
+#endif
 
 int access_amdsmi_topo_numa(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_topo_get_numa_node_number_p)
@@ -497,6 +506,7 @@ int access_amdsmi_device_bdf(int mode, void *arg) {
   return PAPI_OK;
 }
 
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_kfd_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_kfd_info_p)
     return PAPI_ENOSUPP;
@@ -524,6 +534,7 @@ int access_amdsmi_kfd_info(int mode, void *arg) {
   }
   return PAPI_OK;
 }
+#endif
 
 int access_amdsmi_xgmi_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_xgmi_info_p)
@@ -793,6 +804,7 @@ int access_amdsmi_memory_partition_config(int mode, void *arg) {
   return PAPI_OK;
 }
 #endif
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_accelerator_num_partitions(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_accelerator_partition_profile_p)
     return PAPI_ENOSUPP;
@@ -809,6 +821,8 @@ int access_amdsmi_accelerator_num_partitions(int mode, void *arg) {
   event->value = (int64_t)prof.num_partitions;
   return PAPI_OK;
 }
+#endif
+
 /* Access function implementations (read/write operations for each event) */
 int access_amdsmi_temp_metric(int mode, void *arg) {
   native_event_t *event = (native_event_t *)arg;
@@ -2264,8 +2278,13 @@ int access_amdsmi_vram_width(int mode, void *arg) {
   amdsmi_status_t st = amdsmi_get_gpu_vram_info_p(device_handles[event->device], &info);
   if (st != AMDSMI_STATUS_SUCCESS)
     return PAPI_EMISC;
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   event->value = (uint64_t)info.vram_bit_width;
   return PAPI_OK;
+#else
+  (void)info;
+  return PAPI_ENOSUPP;
+#endif
 }
 
 int access_amdsmi_vram_size(int mode, void *arg) {
@@ -2352,7 +2371,7 @@ int access_amdsmi_vram_usage(int mode, void *arg) {
     return PAPI_OK;
   }
 
-  /* USED: keep using vram_usage for the “used” number */
+  /* USED: keep using vram_usage for the Â“usedÂ” number */
   if (!amdsmi_get_gpu_vram_usage_p) return PAPI_ENOSUPP;
 
   amdsmi_vram_usage_t u;
@@ -2724,9 +2743,14 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
   case 12:
     event->value = (int64_t)info.pcie_metric.pcie_nak_received_count;
     break;
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
   case 13:
     event->value = (int64_t)info.pcie_metric.pcie_lc_perf_other_end_recovery_count;
     break;
+#else
+  case 13:
+    return PAPI_ENOSUPP;
+#endif
   default:
     return PAPI_ENOSUPP;
   }
@@ -2786,6 +2810,7 @@ int access_amdsmi_utilization_count(int mode, void *arg) {
   return PAPI_OK;
 }
 
+#if AMDSMI_LIB_VERSION_MAJOR >= 25
 int access_amdsmi_violation_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
@@ -2834,3 +2859,4 @@ int access_amdsmi_violation_status(int mode, void *arg) {
   }
   return PAPI_OK;
 }
+#endif

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -211,6 +211,11 @@ int access_amdsmi_asic_info(int mode, void *arg) {
   return PAPI_OK;
 }
 int access_amdsmi_link_metrics(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   if (mode != PAPI_MODE_READ || !amdsmi_get_link_metrics_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
@@ -281,6 +286,7 @@ int access_amdsmi_link_metrics(int mode, void *arg) {
     total = (uint64_t)INT64_MAX;
   event->value = (int64_t)total;
   return PAPI_OK;
+#endif
 }
 
 #if AMDSMI_VERSION_AT_LEAST(25, 0)
@@ -478,6 +484,11 @@ int access_amdsmi_topo_numa(int mode, void *arg) {
 }
 
 int access_amdsmi_device_bdf(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_device_bdf_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
@@ -506,6 +517,7 @@ int access_amdsmi_device_bdf(int mode, void *arg) {
     return PAPI_ENOSUPP;
   }
   return PAPI_OK;
+#endif
 }
 
 #if PAPI_AMDSMI_BUILD_HAS_24_7
@@ -628,6 +640,11 @@ int access_amdsmi_process_info(int mode, void *arg) {
   return PAPI_OK;
 }
 int access_amdsmi_ecc_total(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_total_ecc_count_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
@@ -660,9 +677,15 @@ int access_amdsmi_ecc_total(int mode, void *arg) {
     val = (uint64_t)INT64_MAX;
   event->value = (int64_t)val;
   return PAPI_OK;
+#endif
 }
 
 int access_amdsmi_ecc_block(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_ecc_count_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
@@ -696,6 +719,7 @@ int access_amdsmi_ecc_block(int mode, void *arg) {
     val = (uint64_t)INT64_MAX;
   event->value = (int64_t)val;
   return PAPI_OK;
+#endif
 }
 
 int access_amdsmi_ecc_status(int mode, void *arg) {
@@ -1018,6 +1042,11 @@ int access_amdsmi_pci_replay_counter(int mode, void *arg) {
   return PAPI_OK;
 }
 int access_amdsmi_clk_freq(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count ||
       !device_handles || !device_handles[event->device]) {
@@ -1053,10 +1082,16 @@ int access_amdsmi_clk_freq(int mode, void *arg) {
     }
   }
   return PAPI_OK;
+#endif
 }
 
 
 int access_amdsmi_clock_info(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count ||
       !device_handles[event->device]) {
@@ -1089,6 +1124,7 @@ int access_amdsmi_clock_info(int mode, void *arg) {
     default: return PAPI_EMISC;
   }
   return PAPI_OK;
+#endif
 }
 
 
@@ -1120,6 +1156,11 @@ int access_amdsmi_metrics_header_info(int mode, void *arg) {
   return PAPI_OK;
 }
 int access_amdsmi_gpu_metrics(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles || !device_handles[event->device]) {
     return PAPI_EMISC;
@@ -1170,6 +1211,7 @@ int access_amdsmi_gpu_metrics(int mode, void *arg) {
     return PAPI_ENOSUPP;
   }
   return PAPI_OK;
+#endif
 }
 int access_amdsmi_gpu_info(int mode, void *arg) {
   native_event_t *event = (native_event_t *)arg;
@@ -1855,6 +1897,11 @@ int access_amdsmi_smu_fw_version(int mode, void *arg) {
 #endif
 
 int access_amdsmi_cache_stat(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles || !device_handles[event->device]) {
     return PAPI_EMISC;
@@ -1890,6 +1937,7 @@ int access_amdsmi_cache_stat(int mode, void *arg) {
   }
   event->value = val;
   return PAPI_OK;
+#endif
 }
 
 int access_amdsmi_overdrive_level(int mode, void *arg) {
@@ -2268,6 +2316,11 @@ int access_amdsmi_voltage(int mode, void *arg) {
 }
 
 int access_amdsmi_vram_width(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles || !device_handles[event->device]) {
     return PAPI_EMISC;
@@ -2289,9 +2342,15 @@ int access_amdsmi_vram_width(int mode, void *arg) {
   (void)info;
   return PAPI_ENOSUPP;
 #endif
+#endif
 }
 
 int access_amdsmi_vram_size(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles || !device_handles[event->device]) {
     return PAPI_EMISC;
@@ -2309,6 +2368,7 @@ int access_amdsmi_vram_size(int mode, void *arg) {
   /* vram_size reported in MB */
   event->value = (uint64_t)info.vram_size * 1024ULL * 1024ULL;
   return PAPI_OK;
+#endif
 }
 
 int access_amdsmi_vram_type(int mode, void *arg) {
@@ -2350,6 +2410,11 @@ int access_amdsmi_vram_vendor(int mode, void *arg) {
 }
 
 int access_amdsmi_vram_usage(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   if (mode != PAPI_MODE_READ) return PAPI_ENOSUPP;
 
   native_event_t *event = (native_event_t *)arg;
@@ -2375,6 +2440,31 @@ int access_amdsmi_vram_usage(int mode, void *arg) {
     return PAPI_OK;
   }
 
+#endif
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
+#endif
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
+#endif
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
+#endif
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
+#endif
   /* USED: keep using vram_usage for the used number */
   if (!amdsmi_get_gpu_vram_usage_p) return PAPI_ENOSUPP;
 
@@ -2512,6 +2602,11 @@ int access_amdsmi_board_serial_hash(int mode, void *arg) {
 }
 
 int access_amdsmi_fw_version(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
   if (!amdsmi_get_fw_info_p)
@@ -2537,6 +2632,7 @@ int access_amdsmi_fw_version(int mode, void *arg) {
     }
   }
   return PAPI_EMISC;
+#endif
 }
 
 #if AMDSMI_VERSION_AT_LEAST(25, 0)
@@ -2688,6 +2784,11 @@ int access_amdsmi_power_sensor(int mode, void *arg) {
 
 
 int access_amdsmi_pcie_info(int mode, void *arg) {
+#if !PAPI_AMDSMI_BUILD_HAS_24_2
+  (void)mode;
+  (void)arg;
+  return PAPI_ENOSUPP;
+#else
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
   if (!amdsmi_get_pcie_info_p)
@@ -2763,6 +2864,7 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
     return PAPI_ENOSUPP;
   }
   return PAPI_OK;
+#endif
 }
 
 int access_amdsmi_event_notification(int mode, void *arg) {

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -135,11 +135,11 @@ int access_amdsmi_gpu_string_hash(int mode, void *arg) {
   event->value = (int64_t)_str_to_u64_hash(buf);
   return PAPI_OK;
 }
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
 int access_amdsmi_enumeration_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_enumeration_info_p)
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(25, 0) || !amdsmi_get_gpu_enumeration_info_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles[event->device])
@@ -283,9 +283,11 @@ int access_amdsmi_link_metrics(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
 int access_amdsmi_xgmi_link_status(int mode, void *arg) {
-  if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_xgmi_link_status_p)
+  if (mode != PAPI_MODE_READ)
+    return PAPI_ENOSUPP;
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(25, 0) || !amdsmi_get_gpu_xgmi_link_status_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count ||
@@ -767,9 +769,11 @@ int access_amdsmi_memory_partition_hash(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
 int access_amdsmi_memory_partition_config(int mode, void *arg) {
-  if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_memory_partition_config_p)
+  if (mode != PAPI_MODE_READ)
+    return PAPI_ENOSUPP;
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(25, 0) || !amdsmi_get_gpu_memory_partition_config_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count ||
@@ -1209,9 +1213,9 @@ int access_amdsmi_gpu_info(int mode, void *arg) {
     }
     break;
   }
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
   case 4: {
-    if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_virtualization_mode_p)
+    if (!AMDS_RUNTIME_VERSION_AT_LEAST(25, 0) || !amdsmi_get_gpu_virtualization_mode_p)
       return PAPI_ENOSUPP;
     amdsmi_virtualization_mode_t mode_val;
     status = amdsmi_get_gpu_virtualization_mode_p(device_handles[event->device], &mode_val);

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -135,11 +135,11 @@ int access_amdsmi_gpu_string_hash(int mode, void *arg) {
   event->value = (int64_t)_str_to_u64_hash(buf);
   return PAPI_OK;
 }
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_enumeration_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_enumeration_info_p)
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_enumeration_info_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles[event->device])
@@ -197,7 +197,7 @@ int access_amdsmi_asic_info(int mode, void *arg) {
   case 4:
     event->value = (int64_t)info.rev_id;
     break;
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
   case 5:
     event->value = (int64_t)info.num_of_compute_units;
     break;
@@ -283,7 +283,7 @@ int access_amdsmi_link_metrics(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_xgmi_link_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_xgmi_link_status_p)
     return PAPI_ENOSUPP;
@@ -365,7 +365,7 @@ int access_amdsmi_link_type(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_p2p_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_topo_get_p2p_status_p)
     return PAPI_ENOSUPP;
@@ -441,7 +441,7 @@ int access_amdsmi_p2p_accessible(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_link_topology_nearest(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_link_topology_nearest_p)
     return PAPI_ENOSUPP;
@@ -506,7 +506,7 @@ int access_amdsmi_device_bdf(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_kfd_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_kfd_info_p)
     return PAPI_ENOSUPP;
@@ -767,7 +767,7 @@ int access_amdsmi_memory_partition_hash(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_memory_partition_config(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_memory_partition_config_p)
     return PAPI_ENOSUPP;
@@ -804,7 +804,7 @@ int access_amdsmi_memory_partition_config(int mode, void *arg) {
   return PAPI_OK;
 }
 #endif
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_accelerator_num_partitions(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_accelerator_partition_profile_p)
     return PAPI_ENOSUPP;
@@ -1209,9 +1209,9 @@ int access_amdsmi_gpu_info(int mode, void *arg) {
     }
     break;
   }
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
   case 4: {
-    if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_virtualization_mode_p)
+    if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_virtualization_mode_p)
       return PAPI_ENOSUPP;
     amdsmi_virtualization_mode_t mode_val;
     status = amdsmi_get_gpu_virtualization_mode_p(device_handles[event->device], &mode_val);
@@ -2076,7 +2076,7 @@ int access_amdsmi_pm_metrics_count(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_pm_metrics_info_p)
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_pm_metrics_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_name_value_t *metrics = NULL;
@@ -2097,7 +2097,7 @@ int access_amdsmi_pm_metric_value(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_pm_metrics_info_p)
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_pm_metrics_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_name_value_t *metrics = NULL;
@@ -2204,7 +2204,7 @@ int access_amdsmi_reg_count(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_reg_table_info_p)
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_reg_table_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_reg_type_t reg_type = (amdsmi_reg_type_t)event->variant; /* set at registration */
@@ -2226,7 +2226,7 @@ int access_amdsmi_reg_value(int mode, void *arg) {
   }
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_reg_table_info_p)
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_reg_table_info_p)
     return PAPI_ENOSUPP;
 
   amdsmi_reg_type_t reg_type = (amdsmi_reg_type_t)event->variant;
@@ -2278,7 +2278,7 @@ int access_amdsmi_vram_width(int mode, void *arg) {
   amdsmi_status_t st = amdsmi_get_gpu_vram_info_p(device_handles[event->device], &info);
   if (st != AMDSMI_STATUS_SUCCESS)
     return PAPI_EMISC;
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
   event->value = (uint64_t)info.vram_bit_width;
   return PAPI_OK;
 #else
@@ -2535,11 +2535,11 @@ int access_amdsmi_fw_version(int mode, void *arg) {
   return PAPI_EMISC;
 }
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (amdsmi_lib_major < 25 || !amdsmi_get_gpu_vram_info_p)
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_vram_info_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles[event->device])
@@ -2666,7 +2666,7 @@ int access_amdsmi_power_sensor(int mode, void *arg) {
   switch (event->variant) {
     case 0: event->value = (int64_t)info.current_socket_power; break; /* W */
     case 1: event->value = (int64_t)info.average_socket_power; break; /* W */
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
     case 2: event->value = (int64_t)info.socket_power; break;         /* uW */
 #endif
     case 3: event->value = (int64_t)info.gfx_voltage; break;          /* mV */
@@ -2694,7 +2694,7 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
     return PAPI_EMISC;
   // Variant mapping:
   // 0 max width, 1 max speed, 2 interface version, 3 slot type,
-  // 4 max interface version (lib >=25),
+  // 4 max interface version (lib >=24.7),
   // 5 current width, 6 current speed, 7 bandwidth,
   // 8 replay count, 9 L0->recovery count, 10 replay rollover count,
   // 11 NAK sent count, 12 NAK received count,
@@ -2712,9 +2712,9 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
   case 3:
     event->value = (int64_t)info.pcie_static.slot_type;
     break;
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
   case 4:
-    if (amdsmi_lib_major < 25)
+    if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7))
       return PAPI_ENOSUPP;
     event->value = (int64_t)info.pcie_static.max_pcie_interface_version;
     break;
@@ -2743,7 +2743,7 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
   case 12:
     event->value = (int64_t)info.pcie_metric.pcie_nak_received_count;
     break;
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
   case 13:
     event->value = (int64_t)info.pcie_metric.pcie_lc_perf_other_end_recovery_count;
     break;
@@ -2810,7 +2810,7 @@ int access_amdsmi_utilization_count(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_violation_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -2539,22 +2539,28 @@ int access_amdsmi_fw_version(int mode, void *arg) {
   return PAPI_EMISC;
 }
 
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
 int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
   if (!amdsmi_get_gpu_vram_info_p)
     return PAPI_ENOSUPP;
+  if (!AMDS_RUNTIME_VERSION_AT_LEAST(25, 0))
+    return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
-  if (event->device < 0 || event->device >= device_count || !device_handles[event->device])
+  if (event->device < 0 || event->device >= device_count ||
+      !device_handles || !device_handles[event->device])
     return PAPI_EMISC;
   amdsmi_vram_info_t info;
   memset(&info, 0, sizeof(info));
-  amdsmi_status_t st = amdsmi_get_gpu_vram_info_p(device_handles[event->device], &info);
+  amdsmi_status_t st =
+      amdsmi_get_gpu_vram_info_p(device_handles[event->device], &info);
   if (st != AMDSMI_STATUS_SUCCESS)
     return PAPI_EMISC;
   event->value = (int64_t)info.vram_max_bandwidth; /* GB/s */
   return PAPI_OK;
 }
+#endif
 
 int access_amdsmi_memory_reserved_pages(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_memory_reserved_pages_p)

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -197,7 +197,7 @@ int access_amdsmi_asic_info(int mode, void *arg) {
   case 4:
     event->value = (int64_t)info.rev_id;
     break;
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
   case 5:
     event->value = (int64_t)info.num_of_compute_units;
     break;
@@ -367,7 +367,7 @@ int access_amdsmi_link_type(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 int access_amdsmi_p2p_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_topo_get_p2p_status_p)
     return PAPI_ENOSUPP;
@@ -443,7 +443,7 @@ int access_amdsmi_p2p_accessible(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 int access_amdsmi_link_topology_nearest(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_link_topology_nearest_p)
     return PAPI_ENOSUPP;
@@ -508,7 +508,7 @@ int access_amdsmi_device_bdf(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 int access_amdsmi_kfd_info(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_kfd_info_p)
     return PAPI_ENOSUPP;
@@ -808,7 +808,7 @@ int access_amdsmi_memory_partition_config(int mode, void *arg) {
   return PAPI_OK;
 }
 #endif
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 int access_amdsmi_accelerator_num_partitions(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_accelerator_partition_profile_p)
     return PAPI_ENOSUPP;
@@ -2282,7 +2282,7 @@ int access_amdsmi_vram_width(int mode, void *arg) {
   amdsmi_status_t st = amdsmi_get_gpu_vram_info_p(device_handles[event->device], &info);
   if (st != AMDSMI_STATUS_SUCCESS)
     return PAPI_EMISC;
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
   event->value = (uint64_t)info.vram_bit_width;
   return PAPI_OK;
 #else
@@ -2539,11 +2539,10 @@ int access_amdsmi_fw_version(int mode, void *arg) {
   return PAPI_EMISC;
 }
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
-  if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7) || !amdsmi_get_gpu_vram_info_p)
+  if (!amdsmi_get_gpu_vram_info_p)
     return PAPI_ENOSUPP;
   native_event_t *event = (native_event_t *)arg;
   if (event->device < 0 || event->device >= device_count || !device_handles[event->device])
@@ -2556,7 +2555,6 @@ int access_amdsmi_vram_max_bandwidth(int mode, void *arg) {
   event->value = (int64_t)info.vram_max_bandwidth; /* GB/s */
   return PAPI_OK;
 }
-#endif
 
 int access_amdsmi_memory_reserved_pages(int mode, void *arg) {
   if (mode != PAPI_MODE_READ || !amdsmi_get_gpu_memory_reserved_pages_p)
@@ -2670,7 +2668,7 @@ int access_amdsmi_power_sensor(int mode, void *arg) {
   switch (event->variant) {
     case 0: event->value = (int64_t)info.current_socket_power; break; /* W */
     case 1: event->value = (int64_t)info.average_socket_power; break; /* W */
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
     case 2: event->value = (int64_t)info.socket_power; break;         /* uW */
 #endif
     case 3: event->value = (int64_t)info.gfx_voltage; break;          /* mV */
@@ -2716,7 +2714,7 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
   case 3:
     event->value = (int64_t)info.pcie_static.slot_type;
     break;
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
   case 4:
     if (!AMDS_RUNTIME_VERSION_AT_LEAST(24, 7))
       return PAPI_ENOSUPP;
@@ -2747,7 +2745,7 @@ int access_amdsmi_pcie_info(int mode, void *arg) {
   case 12:
     event->value = (int64_t)info.pcie_metric.pcie_nak_received_count;
     break;
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
   case 13:
     event->value = (int64_t)info.pcie_metric.pcie_lc_perf_other_end_recovery_count;
     break;
@@ -2814,7 +2812,7 @@ int access_amdsmi_utilization_count(int mode, void *arg) {
   return PAPI_OK;
 }
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 int access_amdsmi_violation_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;

--- a/src/components/amd_smi/amds_funcs.h
+++ b/src/components/amd_smi/amds_funcs.h
@@ -20,8 +20,6 @@
   _(amdsmi_get_utilization_count_p, amdsmi_status_t,                           \
     (amdsmi_processor_handle, amdsmi_utilization_counter_t *, uint32_t,        \
      uint64_t *))                                                              \
-  _(amdsmi_get_violation_status_p, amdsmi_status_t,                            \
-    (amdsmi_processor_handle, amdsmi_violation_status_t *))                    \
   _(amdsmi_get_temp_metric_p, amdsmi_status_t,                                 \
     (amdsmi_processor_handle, amdsmi_temperature_type_t,                       \
      amdsmi_temperature_metric_t, int64_t *))                                  \
@@ -95,9 +93,6 @@
     (amdsmi_processor_handle, char *, uint32_t))                               \
   _(amdsmi_get_gpu_memory_partition_p, amdsmi_status_t,                        \
     (amdsmi_processor_handle, char *, uint32_t))                               \
-  _(amdsmi_get_gpu_accelerator_partition_profile_p, amdsmi_status_t,           \
-    (amdsmi_processor_handle, amdsmi_accelerator_partition_profile_t *,        \
-     uint32_t *))                                                              \
   _(amdsmi_get_gpu_id_p, amdsmi_status_t,                                      \
     (amdsmi_processor_handle, uint16_t *))                                     \
   _(amdsmi_get_gpu_revision_p, amdsmi_status_t,                                \
@@ -123,14 +118,8 @@
   _(amdsmi_topo_get_link_type_p, amdsmi_status_t,                              \
     (amdsmi_processor_handle, amdsmi_processor_handle, uint64_t *,             \
      amdsmi_io_link_type_t *))                                                \
-  _(amdsmi_topo_get_p2p_status_p, amdsmi_status_t,                             \
-    (amdsmi_processor_handle, amdsmi_processor_handle, amdsmi_io_link_type_t *,\
-     amdsmi_p2p_capability_t *))                                              \
   _(amdsmi_is_P2P_accessible_p, amdsmi_status_t,                               \
     (amdsmi_processor_handle, amdsmi_processor_handle, bool *))                \
-  _(amdsmi_get_link_topology_nearest_p, amdsmi_status_t,                       \
-    (amdsmi_processor_handle, amdsmi_link_type_t,                              \
-     amdsmi_topology_nearest_t *))                                            \
   _(amdsmi_get_energy_count_p, amdsmi_status_t,                                \
     (amdsmi_processor_handle, uint64_t *, float *, uint64_t *))                \
   _(amdsmi_get_gpu_power_profile_presets_p, amdsmi_status_t,                   \
@@ -197,8 +186,6 @@
     (amdsmi_event_handle_t, amdsmi_counter_command_t, void *))                \
   _(amdsmi_gpu_read_counter_p, amdsmi_status_t,                                \
     (amdsmi_event_handle_t, amdsmi_counter_value_t *))                        \
-  _(amdsmi_get_gpu_kfd_info_p, amdsmi_status_t,                               \
-    (amdsmi_processor_handle, amdsmi_kfd_info_t *))                           \
   _(amdsmi_is_gpu_memory_partition_supported_p, amdsmi_status_t,              \
     (amdsmi_processor_handle, bool *))                                        \
   _(amdsmi_get_gpu_memory_reserved_pages_p, amdsmi_status_t,                  \
@@ -219,6 +206,19 @@
 #if AMDSMI_LIB_VERSION_MAJOR >= 25
 #define AMD_SMI_GPU_FUNCTIONS(_) \
   AMD_SMI_GPU_FUNCTIONS_BASE(_) \
+  _(amdsmi_get_violation_status_p, amdsmi_status_t, \
+    (amdsmi_processor_handle, amdsmi_violation_status_t *)) \
+  _(amdsmi_get_gpu_accelerator_partition_profile_p, amdsmi_status_t, \
+    (amdsmi_processor_handle, amdsmi_accelerator_partition_profile_t *, \
+     uint32_t *)) \
+  _(amdsmi_topo_get_p2p_status_p, amdsmi_status_t, \
+    (amdsmi_processor_handle, amdsmi_processor_handle, amdsmi_io_link_type_t *, \
+     amdsmi_p2p_capability_t *)) \
+  _(amdsmi_get_link_topology_nearest_p, amdsmi_status_t, \
+    (amdsmi_processor_handle, amdsmi_link_type_t, \
+     amdsmi_topology_nearest_t *)) \
+  _(amdsmi_get_gpu_kfd_info_p, amdsmi_status_t, \
+    (amdsmi_processor_handle, amdsmi_kfd_info_t *)) \
   _(amdsmi_get_gpu_memory_partition_config_p, amdsmi_status_t, \
     (amdsmi_processor_handle, amdsmi_memory_partition_config_t *)) \
   _(amdsmi_get_gpu_xgmi_link_status_p, amdsmi_status_t, \

--- a/src/components/amd_smi/amds_funcs.h
+++ b/src/components/amd_smi/amds_funcs.h
@@ -74,8 +74,6 @@
     (amdsmi_processor_handle, char *, uint32_t))                               \
   _(amdsmi_get_gpu_subsystem_name_p, amdsmi_status_t,                          \
     (amdsmi_processor_handle, char *, size_t))                                 \
-  _(amdsmi_get_link_metrics_p, amdsmi_status_t,                                \
-    (amdsmi_processor_handle, amdsmi_link_metrics_t *))                        \
   _(amdsmi_get_minmax_bandwidth_between_processors_p, amdsmi_status_t,        \
     (amdsmi_processor_handle, amdsmi_processor_handle, uint64_t *,            \
      uint64_t *))                                                             \
@@ -157,10 +155,6 @@
   _(amdsmi_get_processor_count_from_handles_p, amdsmi_status_t,                \
     (amdsmi_processor_handle *, uint32_t *, uint32_t *, uint32_t *,            \
      uint32_t *))                                                              \
-  _(amdsmi_get_soc_pstate_p, amdsmi_status_t,                                  \
-    (amdsmi_processor_handle, amdsmi_dpm_policy_t *))                          \
-  _(amdsmi_get_xgmi_plpd_p, amdsmi_status_t,                                   \
-    (amdsmi_processor_handle, amdsmi_dpm_policy_t *))                          \
   _(amdsmi_get_gpu_bad_page_info_p, amdsmi_status_t,                           \
     (amdsmi_processor_handle, uint32_t *, amdsmi_retired_page_record_t *))     \
   _(amdsmi_get_gpu_bad_page_threshold_p, amdsmi_status_t,                      \
@@ -203,6 +197,16 @@
   _(amdsmi_gpu_destroy_counter_p, amdsmi_status_t,                             \
     (amdsmi_event_handle_t))
 
+#if PAPI_AMDSMI_BUILD_HAS_24_2
+#define AMD_SMI_GPU_FUNCTIONS_24_2(_)                                          \
+  _(amdsmi_get_link_metrics_p, amdsmi_status_t,                                \
+    (amdsmi_processor_handle, amdsmi_link_metrics_t *))                        \
+  _(amdsmi_get_soc_pstate_p, amdsmi_status_t,                                  \
+    (amdsmi_processor_handle, amdsmi_dpm_policy_t *))                          \
+  _(amdsmi_get_xgmi_plpd_p, amdsmi_status_t,                                   \
+    (amdsmi_processor_handle, amdsmi_dpm_policy_t *))
+#endif
+
 #if PAPI_AMDSMI_BUILD_HAS_24_7
 #define AMD_SMI_GPU_FUNCTIONS_24_7(_)                                          \
   _(amdsmi_get_violation_status_p, amdsmi_status_t,                           \
@@ -235,7 +239,13 @@
 #if PAPI_AMDSMI_BUILD_HAS_24_7
 #define AMD_SMI_GPU_FUNCTIONS(_)                                              \
   AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_24_2(_)                                               \
   AMD_SMI_GPU_FUNCTIONS_24_7(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_25_0(_)
+#elif PAPI_AMDSMI_BUILD_HAS_24_2
+#define AMD_SMI_GPU_FUNCTIONS(_)                                              \
+  AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_24_2(_)                                               \
   AMD_SMI_GPU_FUNCTIONS_25_0(_)
 #else
 #define AMD_SMI_GPU_FUNCTIONS(_)                                              \
@@ -245,7 +255,12 @@
 #elif PAPI_AMDSMI_BUILD_HAS_24_7
 #define AMD_SMI_GPU_FUNCTIONS(_)                                              \
   AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_24_2(_)                                               \
   AMD_SMI_GPU_FUNCTIONS_24_7(_)
+#elif PAPI_AMDSMI_BUILD_HAS_24_2
+#define AMD_SMI_GPU_FUNCTIONS(_)                                              \
+  AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_24_2(_)
 #else
 #define AMD_SMI_GPU_FUNCTIONS(_) AMD_SMI_GPU_FUNCTIONS_BASE(_)
 #endif

--- a/src/components/amd_smi/amds_funcs.h
+++ b/src/components/amd_smi/amds_funcs.h
@@ -203,7 +203,7 @@
   _(amdsmi_gpu_destroy_counter_p, amdsmi_status_t,                             \
     (amdsmi_event_handle_t))
 
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 #define AMD_SMI_GPU_FUNCTIONS(_) \
   AMD_SMI_GPU_FUNCTIONS_BASE(_) \
   _(amdsmi_get_violation_status_p, amdsmi_status_t, \

--- a/src/components/amd_smi/amds_funcs.h
+++ b/src/components/amd_smi/amds_funcs.h
@@ -204,29 +204,42 @@
     (amdsmi_event_handle_t))
 
 #if AMDSMI_VERSION_AT_LEAST(24, 7)
-#define AMD_SMI_GPU_FUNCTIONS(_) \
-  AMD_SMI_GPU_FUNCTIONS_BASE(_) \
-  _(amdsmi_get_violation_status_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_violation_status_t *)) \
-  _(amdsmi_get_gpu_accelerator_partition_profile_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_accelerator_partition_profile_t *, \
-     uint32_t *)) \
-  _(amdsmi_topo_get_p2p_status_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_processor_handle, amdsmi_io_link_type_t *, \
-     amdsmi_p2p_capability_t *)) \
-  _(amdsmi_get_link_topology_nearest_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_link_type_t, \
-     amdsmi_topology_nearest_t *)) \
-  _(amdsmi_get_gpu_kfd_info_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_kfd_info_t *)) \
-  _(amdsmi_get_gpu_memory_partition_config_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_memory_partition_config_t *)) \
-  _(amdsmi_get_gpu_xgmi_link_status_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_xgmi_link_status_t *)) \
-  _(amdsmi_get_gpu_enumeration_info_p, amdsmi_status_t, \
-    (amdsmi_processor_handle, amdsmi_enumeration_info_t *)) \
-  _(amdsmi_get_gpu_virtualization_mode_p, amdsmi_status_t, \
+#define AMD_SMI_GPU_FUNCTIONS_24_7(_)                                          \
+  _(amdsmi_get_violation_status_p, amdsmi_status_t,                           \
+    (amdsmi_processor_handle, amdsmi_violation_status_t *))                   \
+  _(amdsmi_get_gpu_accelerator_partition_profile_p, amdsmi_status_t,          \
+    (amdsmi_processor_handle, amdsmi_accelerator_partition_profile_t *,       \
+     uint32_t *))                                                             \
+  _(amdsmi_topo_get_p2p_status_p, amdsmi_status_t,                            \
+    (amdsmi_processor_handle, amdsmi_processor_handle, amdsmi_io_link_type_t *,\
+     amdsmi_p2p_capability_t *))                                              \
+  _(amdsmi_get_link_topology_nearest_p, amdsmi_status_t,                      \
+    (amdsmi_processor_handle, amdsmi_link_type_t,                             \
+     amdsmi_topology_nearest_t *))                                            \
+  _(amdsmi_get_gpu_kfd_info_p, amdsmi_status_t,                                \
+    (amdsmi_processor_handle, amdsmi_kfd_info_t *))
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+#define AMD_SMI_GPU_FUNCTIONS_25_0(_)                                          \
+  _(amdsmi_get_gpu_memory_partition_config_p, amdsmi_status_t,                \
+    (amdsmi_processor_handle, amdsmi_memory_partition_config_t *))            \
+  _(amdsmi_get_gpu_xgmi_link_status_p, amdsmi_status_t,                       \
+    (amdsmi_processor_handle, amdsmi_xgmi_link_status_t *))                   \
+  _(amdsmi_get_gpu_enumeration_info_p, amdsmi_status_t,                       \
+    (amdsmi_processor_handle, amdsmi_enumeration_info_t *))                   \
+  _(amdsmi_get_gpu_virtualization_mode_p, amdsmi_status_t,                    \
     (amdsmi_processor_handle, amdsmi_virtualization_mode_t *))
+#endif
+#endif
+
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+#define AMD_SMI_GPU_FUNCTIONS(_)                                              \
+  AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_24_7(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_25_0(_)
+#elif AMDSMI_VERSION_AT_LEAST(24, 7)
+#define AMD_SMI_GPU_FUNCTIONS(_)                                              \
+  AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_24_7(_)
 #else
 #define AMD_SMI_GPU_FUNCTIONS(_) AMD_SMI_GPU_FUNCTIONS_BASE(_)
 #endif

--- a/src/components/amd_smi/amds_funcs.h
+++ b/src/components/amd_smi/amds_funcs.h
@@ -203,7 +203,7 @@
   _(amdsmi_gpu_destroy_counter_p, amdsmi_status_t,                             \
     (amdsmi_event_handle_t))
 
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 #define AMD_SMI_GPU_FUNCTIONS_24_7(_)                                          \
   _(amdsmi_get_violation_status_p, amdsmi_status_t,                           \
     (amdsmi_processor_handle, amdsmi_violation_status_t *))                   \
@@ -232,11 +232,17 @@
 #endif
 
 #if AMDSMI_VERSION_AT_LEAST(25, 0)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 #define AMD_SMI_GPU_FUNCTIONS(_)                                              \
   AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
   AMD_SMI_GPU_FUNCTIONS_24_7(_)                                               \
   AMD_SMI_GPU_FUNCTIONS_25_0(_)
-#elif AMDSMI_VERSION_AT_LEAST(24, 7)
+#else
+#define AMD_SMI_GPU_FUNCTIONS(_)                                              \
+  AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
+  AMD_SMI_GPU_FUNCTIONS_25_0(_)
+#endif
+#elif PAPI_AMDSMI_BUILD_HAS_24_7
 #define AMD_SMI_GPU_FUNCTIONS(_)                                              \
   AMD_SMI_GPU_FUNCTIONS_BASE(_)                                               \
   AMD_SMI_GPU_FUNCTIONS_24_7(_)

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -9,6 +9,14 @@
 #ifndef AMDSMI_LIB_VERSION_MAJOR
 #define AMDSMI_LIB_VERSION_MAJOR 0
 #endif
+#ifndef AMDSMI_LIB_VERSION_MINOR
+#define AMDSMI_LIB_VERSION_MINOR 0
+#endif
+
+#define AMDSMI_VERSION_AT_LEAST(maj, min)                                      \
+  ((AMDSMI_LIB_VERSION_MAJOR > (maj)) ||                                      \
+   (AMDSMI_LIB_VERSION_MAJOR == (maj) &&                                      \
+    AMDSMI_LIB_VERSION_MINOR >= (min)))
 
 /* Mode enumeration used by accessors */
 typedef enum {
@@ -49,6 +57,7 @@ uint32_t *amds_get_cores_per_socket(void);
 void *amds_get_htable(void);
 native_event_table_t *amds_get_ntv_table(void);
 uint32_t amds_get_lib_major(void);
+uint32_t amds_get_lib_minor(void);
 
 #ifndef AMDS_PRIV_IMPL
 #define device_handles (amds_get_device_handles())
@@ -60,6 +69,10 @@ uint32_t amds_get_lib_major(void);
 #define htable (amds_get_htable())
 #define ntv_table_p (amds_get_ntv_table())
 #define amdsmi_lib_major (amds_get_lib_major())
+#define amdsmi_lib_minor (amds_get_lib_minor())
+#define AMDS_RUNTIME_VERSION_AT_LEAST(maj, min)                                \
+  ((amdsmi_lib_major > (maj)) ||                                              \
+   (amdsmi_lib_major == (maj) && amdsmi_lib_minor >= (min)))
 #endif
 
 /* AMD SMI function pointers */
@@ -151,8 +164,8 @@ int access_amdsmi_event_notification(int mode, void *arg);
 int access_amdsmi_xgmi_bandwidth(int mode, void *arg);
 int access_amdsmi_utilization_count(int mode, void *arg);
 
-/* Consolidated AMDSMI_LIB_VERSION_MAJOR >= 25 block */
-#if AMDSMI_LIB_VERSION_MAJOR >= 25
+/* Consolidated AMD SMI additions introduced in 24.7 */
+#if AMDSMI_VERSION_AT_LEAST(24, 7)
 int access_amdsmi_accelerator_num_partitions(int mode, void *arg);
 int access_amdsmi_kfd_info(int mode, void *arg);
 int access_amdsmi_link_topology_nearest(int mode, void *arg);

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -18,6 +18,26 @@
    (AMDSMI_LIB_VERSION_MAJOR == (maj) &&                                      \
     AMDSMI_LIB_VERSION_MINOR >= (min)))
 
+/*
+ * Some AMD SMI 24.7 symbols/types were introduced incrementally across ROCm
+ * drops.  Older 24.x headers advertise the newer version numbers but lack the
+ * associated structs/constants entirely.  Detect availability via the helper
+ * macros that accompany those additions so we can compile cleanly against
+ * pre-24.7 SDKs.
+ */
+#if defined(AMDSMI_COARSE_DECODER_ACTIVITY) &&                                 \
+    defined(AMDSMI_MAX_ACCELERATOR_PARTITIONS)
+#define PAPI_AMDSMI_HAS_24_7_HEADERS 1
+#else
+#define PAPI_AMDSMI_HAS_24_7_HEADERS 0
+#endif
+
+#if PAPI_AMDSMI_HAS_24_7_HEADERS && AMDSMI_VERSION_AT_LEAST(24, 7)
+#define PAPI_AMDSMI_BUILD_HAS_24_7 1
+#else
+#define PAPI_AMDSMI_BUILD_HAS_24_7 0
+#endif
+
 /* Mode enumeration used by accessors */
 typedef enum {
   PAPI_MODE_READ = 1,
@@ -165,19 +185,20 @@ int access_amdsmi_xgmi_bandwidth(int mode, void *arg);
 int access_amdsmi_utilization_count(int mode, void *arg);
 
 /* Consolidated AMD SMI additions introduced in 24.7 */
-#if AMDSMI_VERSION_AT_LEAST(24, 7)
+#if PAPI_AMDSMI_BUILD_HAS_24_7
 int access_amdsmi_accelerator_num_partitions(int mode, void *arg);
 int access_amdsmi_kfd_info(int mode, void *arg);
 int access_amdsmi_link_topology_nearest(int mode, void *arg);
 int access_amdsmi_p2p_status(int mode, void *arg);
 int access_amdsmi_violation_status(int mode, void *arg);
-int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
 #if AMDSMI_VERSION_AT_LEAST(25, 0)
 int access_amdsmi_enumeration_info(int mode, void *arg);
 int access_amdsmi_memory_partition_config(int mode, void *arg);
 int access_amdsmi_xgmi_link_status(int mode, void *arg);
 #endif
 #endif
+
+int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
 
 #ifndef AMDSMI_DISABLE_ESMI
 int access_amdsmi_cpu_socket_power(int mode, void *arg);

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -171,10 +171,12 @@ int access_amdsmi_kfd_info(int mode, void *arg);
 int access_amdsmi_link_topology_nearest(int mode, void *arg);
 int access_amdsmi_p2p_status(int mode, void *arg);
 int access_amdsmi_violation_status(int mode, void *arg);
+int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
 int access_amdsmi_enumeration_info(int mode, void *arg);
 int access_amdsmi_memory_partition_config(int mode, void *arg);
 int access_amdsmi_xgmi_link_status(int mode, void *arg);
-int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
+#endif
 #endif
 
 #ifndef AMDSMI_DISABLE_ESMI

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -97,12 +97,9 @@ int access_amdsmi_asic_info(int mode, void *arg);
 int access_amdsmi_link_metrics(int mode, void *arg);
 int access_amdsmi_link_weight(int mode, void *arg);
 int access_amdsmi_link_type(int mode, void *arg);
-int access_amdsmi_p2p_status(int mode, void *arg);
 int access_amdsmi_p2p_accessible(int mode, void *arg);
-int access_amdsmi_link_topology_nearest(int mode, void *arg);
 int access_amdsmi_topo_numa(int mode, void *arg);
 int access_amdsmi_device_bdf(int mode, void *arg);
-int access_amdsmi_kfd_info(int mode, void *arg);
 int access_amdsmi_xgmi_info(int mode, void *arg);
 int access_amdsmi_process_info(int mode, void *arg);
 int access_amdsmi_ecc_total(int mode, void *arg);
@@ -112,7 +109,6 @@ int access_amdsmi_ecc_enabled_mask(int mode, void *arg);
 int access_amdsmi_compute_partition_hash(int mode, void *arg);
 int access_amdsmi_memory_partition_hash(int mode, void *arg);
 int access_amdsmi_memory_reserved_pages(int mode, void *arg);
-int access_amdsmi_accelerator_num_partitions(int mode, void *arg);
 int access_amdsmi_lib_version(int mode, void *arg);
 int access_amdsmi_cache_stat(int mode, void *arg);
 int access_amdsmi_overdrive_level(int mode, void *arg);
@@ -154,10 +150,14 @@ int access_amdsmi_pcie_info(int mode, void *arg);
 int access_amdsmi_event_notification(int mode, void *arg);
 int access_amdsmi_xgmi_bandwidth(int mode, void *arg);
 int access_amdsmi_utilization_count(int mode, void *arg);
-int access_amdsmi_violation_status(int mode, void *arg);
 
 /* Consolidated AMDSMI_LIB_VERSION_MAJOR >= 25 block */
 #if AMDSMI_LIB_VERSION_MAJOR >= 25
+int access_amdsmi_accelerator_num_partitions(int mode, void *arg);
+int access_amdsmi_kfd_info(int mode, void *arg);
+int access_amdsmi_link_topology_nearest(int mode, void *arg);
+int access_amdsmi_p2p_status(int mode, void *arg);
+int access_amdsmi_violation_status(int mode, void *arg);
 int access_amdsmi_enumeration_info(int mode, void *arg);
 int access_amdsmi_memory_partition_config(int mode, void *arg);
 int access_amdsmi_xgmi_link_status(int mode, void *arg);

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -19,6 +19,27 @@
     AMDSMI_LIB_VERSION_MINOR >= (min)))
 
 /*
+ * ROCm 6.0/6.1 shipped AMD SMI 24.x headers that predated a number of helper
+ * enums/struct fields used by the newer topology, clock and policy queries.
+ * Probe for the accompanying macros so we can fence those call paths when
+ * targeting SDKs older than 24.2.
+ */
+#if defined(AMDSMI_PROCESSOR_TYPE_AMD_GPU) &&                                  \
+    defined(AMDSMI_TEMPERATURE_TYPE_EDGE) &&                                   \
+    defined(AMDSMI_GPU_BLOCK_VCN) &&                                           \
+    defined(AMDSMI_CLK_TYPE_SYS)
+#define PAPI_AMDSMI_HAS_24_2_HEADERS 1
+#else
+#define PAPI_AMDSMI_HAS_24_2_HEADERS 0
+#endif
+
+#if PAPI_AMDSMI_HAS_24_2_HEADERS && AMDSMI_VERSION_AT_LEAST(24, 2)
+#define PAPI_AMDSMI_BUILD_HAS_24_2 1
+#else
+#define PAPI_AMDSMI_BUILD_HAS_24_2 0
+#endif
+
+/*
  * Some AMD SMI 24.7 symbols/types were introduced incrementally across ROCm
  * drops.  Older 24.x headers advertise the newer version numbers but lack the
  * associated structs/constants entirely.  Detect availability via the helper
@@ -36,6 +57,11 @@
 #define PAPI_AMDSMI_BUILD_HAS_24_7 1
 #else
 #define PAPI_AMDSMI_BUILD_HAS_24_7 0
+#endif
+
+#if PAPI_AMDSMI_BUILD_HAS_24_7 && !PAPI_AMDSMI_BUILD_HAS_24_2
+#undef PAPI_AMDSMI_BUILD_HAS_24_2
+#define PAPI_AMDSMI_BUILD_HAS_24_2 1
 #endif
 
 /* Mode enumeration used by accessors */

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -160,6 +160,9 @@ int access_amdsmi_ras_block_state(int mode, void *arg);
 int access_amdsmi_reg_count(int mode, void *arg);
 int access_amdsmi_reg_value(int mode, void *arg);
 int access_amdsmi_voltage(int mode, void *arg);
+#if AMDSMI_VERSION_AT_LEAST(25, 0)
+int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
+#endif
 int access_amdsmi_vram_width(int mode, void *arg);
 int access_amdsmi_vram_size(int mode, void *arg);
 int access_amdsmi_vram_type(int mode, void *arg);
@@ -198,7 +201,6 @@ int access_amdsmi_xgmi_link_status(int mode, void *arg);
 #endif
 #endif
 
-int access_amdsmi_vram_max_bandwidth(int mode, void *arg);
 
 #ifndef AMDSMI_DISABLE_ESMI
 int access_amdsmi_cpu_socket_power(int mode, void *arg);


### PR DESCRIPTION
## Summary
- gate function-pointer declarations and dynamic symbol lookups for AMD SMI features that only exist from library major version 25
- guard accessor prototypes and implementations that rely on new AMD SMI types, and provide fallbacks when structure members are absent
- conditionally compile decoder utilization counters and newer PCIe/VRAM metrics so older ROCm headers continue to build

## Testing
- make -C src *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e26abaa8832bb83c77aa5f061a44