### PR TITLE
Standardize AMD SMI error variable names

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -750,10 +750,10 @@ static int add_event(int *idx_ptr, const char *name, const char *descr, int devi
 
 static int add_counter_event(int *idx_ptr, const char *name, const char *descr,
                              int device, uint32_t variant, uint32_t subvariant) {
-  int ret = add_event(idx_ptr, name, descr, device, variant, subvariant,
-                      PAPI_MODE_READ, access_amdsmi_gpu_counter);
-  if (ret != PAPI_OK)
-    return ret;
+  int papi_errno = add_event(idx_ptr, name, descr, device, variant, subvariant,
+                             PAPI_MODE_READ, access_amdsmi_gpu_counter);
+  if (papi_errno != PAPI_OK)
+    return papi_errno;
   native_event_t *ev = &ntv_table.events[*idx_ptr - 1];
   ev->open_func = open_counter;
   ev->close_func = close_counter;

--- a/src/components/amd_smi/amds_ctx.c
+++ b/src/components/amd_smi/amds_ctx.c
@@ -127,9 +127,9 @@ int amds_ctx_stop(amds_ctx_t ctx) {
   for (int i = 0; i < ctx->num_events; ++i) {
     native_event_t *ev = &ntv_table_p->events[ctx->events_id[i]];
     if (ev->stop_func) {
-      int ret = ev->stop_func(ev);
+      int papi_errno_stop = ev->stop_func(ev);
       if (papi_errno == PAPI_OK)
-        papi_errno = ret;
+        papi_errno = papi_errno_stop;
     }
   }
   ctx->state &= ~AMDS_EVENTS_RUNNING;
@@ -150,14 +150,14 @@ int amds_ctx_read(amds_ctx_t ctx, long long **counts) {
     unsigned int id = ctx->events_id[i];
     native_event_t *ev = &ntv_table_p->events[id];
 
-    int rc = PAPI_OK;
+    int papi_errno_access = PAPI_OK;
     if (ev->access_func) {
-      rc = ev->access_func(PAPI_MODE_READ, ev);
+      papi_errno_access = ev->access_func(PAPI_MODE_READ, ev);
     }
-    if (rc == PAPI_OK) {
+    if (papi_errno_access == PAPI_OK) {
       ctx->counters[i] = (long long)ev->value;
     } else if (papi_errno == PAPI_OK) {
-      papi_errno = rc;  /* remember, but keep going */
+      papi_errno = papi_errno_access;  /* remember, but keep going */
     }
   }
 

--- a/src/components/amd_smi/linux-amd-smi.c
+++ b/src/components/amd_smi/linux-amd-smi.c
@@ -216,9 +216,9 @@ static int _amd_smi_stop(hwd_context_t *ctx, hwd_control_state_t *ctrl) {
   amdsmi_control_t *amdsmi_ctl = (amdsmi_control_t *)ctrl;
   if (!(amdsmi_ctx->state & AMDS_EVENTS_RUNNING)) return PAPI_EMISC;
 
-  int rc = amds_ctx_stop(amdsmi_ctl->amds_ctx);
+  int papi_errno = amds_ctx_stop(amdsmi_ctl->amds_ctx);
   amdsmi_ctx->state &= ~AMDS_EVENTS_RUNNING;
-  return rc;
+  return papi_errno;
 }
 
 static int _amd_smi_reset(hwd_context_t *ctx, hwd_control_state_t *ctrl) {


### PR DESCRIPTION
## Summary
- rename local return variables in the AMD SMI helpers to papi_errno for consistent error handling
- update amds_ctx stop/read paths to use papi_errno-based temporaries while preserving first-error tracking
- align the linux wrapper stop routine with the papi_errno naming convention

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9b6456d0c832ba43c78e8501d5ed7