### PR TITLE
Normalize AMD SMI return code variable names

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -121,10 +121,10 @@ static int open_counter(native_event_t *event) {
   counter_priv_t *priv = (counter_priv_t *)papi_calloc(1, sizeof(counter_priv_t));
   if (!priv)
     return PAPI_ENOMEM;
-  amdsmi_status_t ret = amdsmi_gpu_create_counter_p(
+  amdsmi_status_t status = amdsmi_gpu_create_counter_p(
       device_handles[event->device], (amdsmi_event_type_t)event->variant,
       &priv->handle);
-  if (ret != AMDSMI_STATUS_SUCCESS) {
+  if (status != AMDSMI_STATUS_SUCCESS) {
     papi_free(priv);
     return PAPI_ENOSUPP;
   }
@@ -148,18 +148,18 @@ static int start_counter(native_event_t *event) {
   if (!priv || !amdsmi_gpu_control_counter_p)
     return PAPI_ENOSUPP;
   priv->accum = 0;
-  amdsmi_status_t ret = amdsmi_gpu_control_counter_p(
+  amdsmi_status_t status = amdsmi_gpu_control_counter_p(
       priv->handle, AMDSMI_CNTR_CMD_START, NULL);
-  return (ret == AMDSMI_STATUS_SUCCESS) ? PAPI_OK : PAPI_ENOSUPP;
+  return (status == AMDSMI_STATUS_SUCCESS) ? PAPI_OK : PAPI_ENOSUPP;
 }
 
 static int stop_counter(native_event_t *event) {
   counter_priv_t *priv = (counter_priv_t *)event->priv;
   if (!priv || !amdsmi_gpu_control_counter_p)
     return PAPI_ENOSUPP;
-  amdsmi_status_t ret =
+  amdsmi_status_t status =
       amdsmi_gpu_control_counter_p(priv->handle, AMDSMI_CNTR_CMD_STOP, NULL);
-  return (ret == AMDSMI_STATUS_SUCCESS) ? PAPI_OK : PAPI_ENOSUPP;
+  return (status == AMDSMI_STATUS_SUCCESS) ? PAPI_OK : PAPI_ENOSUPP;
 }
 
 static int access_amdsmi_gpu_counter(int mode, void *arg) {
@@ -3276,10 +3276,10 @@ static int init_event_table(void) {
     if (amdsmi_get_gpu_memory_partition_p) {
       char part[128] = {0};
       uint32_t len = (uint32_t)sizeof(part);
-      amdsmi_status_t rc =
+      amdsmi_status_t status =
           amdsmi_get_gpu_memory_partition_p(device_handles[d], part, len);
       part[sizeof(part) - 1] = '\0';  // belt-and-suspenders NUL
-      if (rc == AMDSMI_STATUS_SUCCESS && part[0] != '\0') {
+      if (status == AMDSMI_STATUS_SUCCESS && part[0] != '\0') {
         CHECK_EVENT_IDX(idx);
         snprintf(name_buf, sizeof(name_buf), "memory_partition_hash:device=%d", d);
         snprintf(descr_buf, sizeof(descr_buf), "Device %d memory partition (hash)", d);
@@ -3315,9 +3315,9 @@ static int init_event_table(void) {
     if (amdsmi_get_gpu_accelerator_partition_profile_p) {
       amdsmi_accelerator_partition_profile_t prof = {0};
       uint32_t ids[AMDSMI_MAX_ACCELERATOR_PARTITIONS] = {0};
-      amdsmi_status_t rc =
+      amdsmi_status_t status =
           amdsmi_get_gpu_accelerator_partition_profile_p(device_handles[d], &prof, ids);
-      if (rc == AMDSMI_STATUS_SUCCESS &&
+      if (status == AMDSMI_STATUS_SUCCESS &&
           prof.num_partitions > 0 &&
           prof.num_partitions <= AMDSMI_MAX_ACCELERATOR_PARTITIONS) {
         CHECK_EVENT_IDX(idx);

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -1701,9 +1701,9 @@ int access_amdsmi_cpu_prochot_status(int mode, void *arg) {
   if (mode != PAPI_MODE_READ)
     return PAPI_ENOSUPP;
   uint32_t status = 0;
-  amdsmi_status_t ret = amdsmi_get_cpu_prochot_status_p(
+  amdsmi_status_t smi_status = amdsmi_get_cpu_prochot_status_p(
       device_handles[event->device], &status);
-  if (ret != AMDSMI_STATUS_SUCCESS)
+  if (smi_status != AMDSMI_STATUS_SUCCESS)
     return PAPI_EMISC;
   event->value = status;
   return PAPI_OK;
@@ -2359,7 +2359,7 @@ int access_amdsmi_vram_usage(int mode, void *arg) {
     return PAPI_OK;
   }
 
-  /* USED: keep using vram_usage for the “used” number */
+  /* USED: keep using vram_usage for the Â“usedÂ” number */
   if (!amdsmi_get_gpu_vram_usage_p) return PAPI_ENOSUPP;
 
   amdsmi_vram_usage_t u;

--- a/src/components/amd_smi/tests/amdsmi_energy_monotonic.c
+++ b/src/components/amd_smi/tests/amdsmi_energy_monotonic.c
@@ -33,42 +33,42 @@ int main(int argc, char **argv) {
     }
 
     // Initialize the PAPI library.
-    int ret = PAPI_library_init(PAPI_VER_CURRENT);
-    if (ret != PAPI_VER_CURRENT) {
-        NOTE("PAPI_library_init failed: %s", PAPI_strerror(ret));
+    int papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    if (papi_errno != PAPI_VER_CURRENT) {
+        NOTE("PAPI_library_init failed: %s", PAPI_strerror(papi_errno));
         return eval_result(opts, 1);
     }
 
     // Create an empty event set and add the AMD-SMI energy counter for device 0.
     int EventSet = PAPI_NULL;
-    ret = PAPI_create_eventset(&EventSet);
-    if (ret != PAPI_OK) {
-        NOTE("PAPI_create_eventset: %s", PAPI_strerror(ret));
+    papi_errno = PAPI_create_eventset(&EventSet);
+    if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_create_eventset: %s", PAPI_strerror(papi_errno));
         return eval_result(opts, 1);
     }
 
     const char *ev = "amd_smi:::energy_consumed:device=0";
-    ret = PAPI_add_named_event(EventSet, ev);
-    if (ret == PAPI_ENOEVNT) {
+    papi_errno = PAPI_add_named_event(EventSet, ev);
+    if (papi_errno == PAPI_ENOEVNT) {
         SKIP("energy_consumed:device=0 not supported");
-    } else if (ret != PAPI_OK) {
-        NOTE("PAPI_add_named_event(%s): %s", ev, PAPI_strerror(ret));
+    } else if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_add_named_event(%s): %s", ev, PAPI_strerror(papi_errno));
         return eval_result(opts, 1);
     }
 
     // Begin counting.
-    ret = PAPI_start(EventSet);
-    if (ret != PAPI_OK) {
-        NOTE("PAPI_start: %s", PAPI_strerror(ret));
+    papi_errno = PAPI_start(EventSet);
+    if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_start: %s", PAPI_strerror(papi_errno));
         return eval_result(opts, 1);
     }
 
     long long v1 = 0, v2 = 0;
 
     // First sample.
-    ret = PAPI_read(EventSet, &v1);
-    if (ret != PAPI_OK) {
-        NOTE("PAPI_read(1): %s", PAPI_strerror(ret));
+    papi_errno = PAPI_read(EventSet, &v1);
+    if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_read(1): %s", PAPI_strerror(papi_errno));
         long long dummy = 0; PAPI_stop(EventSet, &dummy);
         return eval_result(opts, 1);
     }
@@ -77,9 +77,9 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 10; ++i) {
         usleep(100000); // 100 ms
 
-        ret = PAPI_read(EventSet, &v2);
-        if (ret != PAPI_OK) {
-            NOTE("PAPI_read(2): %s", PAPI_strerror(ret));
+        papi_errno = PAPI_read(EventSet, &v2);
+        if (papi_errno != PAPI_OK) {
+            NOTE("PAPI_read(2): %s", PAPI_strerror(papi_errno));
             long long dummy = 0; PAPI_stop(EventSet, &dummy);
             return eval_result(opts, 1);
         }

--- a/src/components/amd_smi/tests/amdsmi_gemm.c
+++ b/src/components/amd_smi/tests/amdsmi_gemm.c
@@ -301,6 +301,6 @@ static int real_main(const HarnessOpts *opts) {
 int main(int argc, char *argv[]) {
     harness_accept_tests_quiet(&argc, argv);
     HarnessOpts opts = parse_harness_cli(argc, argv);
-    int rc = real_main(&opts);
-    return eval_result(opts, rc);
+    int papi_errno = real_main(&opts);
+    return eval_result(opts, papi_errno);
 }

--- a/src/components/amd_smi/tests/amdsmi_hello.c
+++ b/src/components/amd_smi/tests/amdsmi_hello.c
@@ -36,38 +36,40 @@ int main(int argc, char** argv) {
     }
 
     // Initialize PAPI.
-    int rc = PAPI_library_init(PAPI_VER_CURRENT);
-    if (rc != PAPI_VER_CURRENT) {
-        NOTE("PAPI_library_init failed: %s", PAPI_strerror(rc));
+    int papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    if (papi_errno != PAPI_VER_CURRENT) {
+        NOTE("PAPI_library_init failed: %s", PAPI_strerror(papi_errno));
         return eval_result(opts, 1);
     }
 
     // Create an EventSet.
     int EventSet = PAPI_NULL;
-    rc = PAPI_create_eventset(&EventSet);
-    if (rc != PAPI_OK) {
-        NOTE("PAPI_create_eventset: %s", PAPI_strerror(rc));
+    papi_errno = PAPI_create_eventset(&EventSet);
+    if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_create_eventset: %s", PAPI_strerror(papi_errno));
         return eval_result(opts, 1);
     }
 
     // Add the selected event.
-    rc = PAPI_add_named_event(EventSet, ev);
-    if (rc == PAPI_ENOEVNT || rc == PAPI_ECNFLCT || rc == PAPI_EPERM) {
-        NOTE("Event unavailable or HW/resource-limited: %s (%s)", ev, PAPI_strerror(rc));
+    papi_errno = PAPI_add_named_event(EventSet, ev);
+    if (papi_errno == PAPI_ENOEVNT || papi_errno == PAPI_ECNFLCT ||
+        papi_errno == PAPI_EPERM) {
+        NOTE("Event unavailable or HW/resource-limited: %s (%s)", ev,
+             PAPI_strerror(papi_errno));
         SKIP("Event unavailable or HW/resource-limited");
-    } else if (rc != PAPI_OK) {
-        NOTE("PAPI_add_named_event(%s): %s", ev, PAPI_strerror(rc));
+    } else if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_add_named_event(%s): %s", ev, PAPI_strerror(papi_errno));
         PAPI_destroy_eventset(&EventSet);
         return eval_result(opts, 1);
     }
 
     // Start counters -> short wait -> stop/read.
-    rc = PAPI_start(EventSet);
-    if (rc == PAPI_ECNFLCT || rc == PAPI_EPERM) {
-        NOTE("Cannot start counters: %s", PAPI_strerror(rc));
+    papi_errno = PAPI_start(EventSet);
+    if (papi_errno == PAPI_ECNFLCT || papi_errno == PAPI_EPERM) {
+        NOTE("Cannot start counters: %s", PAPI_strerror(papi_errno));
         SKIP("Cannot start counters");
-    } else if (rc != PAPI_OK) {
-        NOTE("PAPI_start: %s", PAPI_strerror(rc));
+    } else if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_start: %s", PAPI_strerror(papi_errno));
         PAPI_destroy_eventset(&EventSet);
         return eval_result(opts, 1);
     }
@@ -75,9 +77,9 @@ int main(int argc, char** argv) {
     usleep(100000); // ~100 ms sampling interval for this simple demo.
 
     long long val = 0;
-    rc = PAPI_stop(EventSet, &val);
-    if (rc != PAPI_OK) {
-        NOTE("PAPI_stop: %s", PAPI_strerror(rc));
+    papi_errno = PAPI_stop(EventSet, &val);
+    if (papi_errno != PAPI_OK) {
+        NOTE("PAPI_stop: %s", PAPI_strerror(papi_errno));
         PAPI_destroy_eventset(&EventSet);
         return eval_result(opts, 1);
     }


### PR DESCRIPTION
## Summary
- rename AMD SMI counter status variables from generic `ret`/`rc` names to descriptive `status`
- standardize AMD SMI tests to use the `papi_errno` naming convention for PAPI return codes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9ba70c8dc832b92a946767c8d34f8