### PR TITLE
Allow amd_smi reset on stopped EventSets

### DIFF
--- a/src/components/amd_smi/linux-amd-smi.c
+++ b/src/components/amd_smi/linux-amd-smi.c
@@ -222,11 +222,15 @@ static int _amd_smi_stop(hwd_context_t *ctx, hwd_control_state_t *ctrl) {
 }
 
 static int _amd_smi_reset(hwd_context_t *ctx, hwd_control_state_t *ctrl) {
-    amdsmi_context_t *amdsmi_ctx = (amdsmi_context_t *) ctx;
+    (void) ctx;
     amdsmi_control_t *amdsmi_ctl = (amdsmi_control_t *) ctrl;
-    if (!(amdsmi_ctx->state & AMDS_EVENTS_RUNNING)) {
-        return PAPI_EMISC;
+
+    if (!amdsmi_ctl->amds_ctx) {
+        /* Resetting is allowed even if the EventSet was never started. */
+        return PAPI_OK;
     }
+
+    /* Clear accumulated values regardless of whether the EventSet is running. */
     return amds_ctx_reset(amdsmi_ctl->amds_ctx);
 }
 


### PR DESCRIPTION
## Summary
- allow `_amd_smi_reset` to succeed even when the EventSet is not running
- no-op when no AMD SMI context is open and otherwise keep using `amds_ctx_reset`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9dcd0edf8832bb5965c5a3e2d4012