### PR TITLE
Improve AMD SMI link type compatibility

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -3372,10 +3372,12 @@ static int init_event_table(void) {
       amdsmi_link_metrics_t lm;
       if (amdsmi_get_link_metrics_p(device_handles[d], &lm) ==
           AMDSMI_STATUS_SUCCESS) {
-        int types[] = {AMDSMI_LINK_TYPE_XGMI, AMDSMI_LINK_TYPE_PCIE};
+        int types[] = {PAPI_AMDSMI_LINK_TYPE_XGMI, PAPI_AMDSMI_LINK_TYPE_PCIE};
         const char *type_names[] = {"xgmi", "pcie"};
         for (int ti = 0; ti < 2; ++ti) {
           uint32_t link_type = (uint32_t)types[ti];
+          if (link_type == 0)
+            continue;
           uint32_t sv = (link_type << 16) | 0xFFFF;
           int present = 0;
           uint32_t n = lm.num_links;
@@ -3442,10 +3444,12 @@ static int init_event_table(void) {
       }
     }
     if (amdsmi_get_link_topology_nearest_p) {
-      amdsmi_link_type_t lt_types[] = {AMDSMI_LINK_TYPE_XGMI,
-                                       AMDSMI_LINK_TYPE_PCIE};
+      papi_amdsmi_link_type_t lt_types[] = {PAPI_AMDSMI_LINK_TYPE_XGMI,
+                                            PAPI_AMDSMI_LINK_TYPE_PCIE};
       const char *lt_names[] = {"xgmi", "pcie"};
       for (int ti = 0; ti < 2; ++ti) {
+        if (lt_types[ti] == 0)
+          continue;
         amdsmi_topology_nearest_t info;
         memset(&info, 0, sizeof(info));
         if (amdsmi_get_link_topology_nearest_p(device_handles[d], lt_types[ti],

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -451,7 +451,7 @@ int access_amdsmi_link_topology_nearest(int mode, void *arg) {
   amdsmi_topology_nearest_t info;
   memset(&info, 0, sizeof(info));
   if (amdsmi_get_link_topology_nearest_p(
-          device_handles[event->device], (amdsmi_link_type_t)event->variant,
+          device_handles[event->device], (papi_amdsmi_link_type_t)event->variant,
           &info) != AMDSMI_STATUS_SUCCESS)
     return PAPI_EMISC;
   event->value = (int64_t)info.count;

--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -17,6 +17,41 @@
 #define AMDSMI_LIB_VERSION_MAJOR 0
 #endif
 
+/*
+ * AMD SMI 7.0 (library v26) renamed amdsmi_io_link_type_t to
+ * amdsmi_link_type_t.  Provide aliases so the component can be built
+ * against either v25 or v26 headers while continuing to use the older
+ * symbol names internally.
+ */
+#if AMDSMI_LIB_VERSION_MAJOR >= 26
+typedef amdsmi_link_type_t amdsmi_io_link_type_t;
+#else
+typedef amdsmi_io_link_type_t amdsmi_link_type_t;
+#endif
+
+typedef amdsmi_link_type_t papi_amdsmi_link_type_t;
+
+#if AMDSMI_LIB_VERSION_MAJOR > 0 && AMDSMI_LIB_VERSION_MAJOR < 25
+#error "AMD SMI library version 25 or newer is required"
+#endif
+
+/* Convenience macros for the link type constants used by the component. */
+#if defined(AMDSMI_LINK_TYPE_XGMI)
+#define PAPI_AMDSMI_LINK_TYPE_XGMI AMDSMI_LINK_TYPE_XGMI
+#elif defined(AMDSMI_IOLINK_TYPE_XGMI)
+#define PAPI_AMDSMI_LINK_TYPE_XGMI AMDSMI_IOLINK_TYPE_XGMI
+#else
+#define PAPI_AMDSMI_LINK_TYPE_XGMI 0
+#endif
+
+#if defined(AMDSMI_LINK_TYPE_PCIE)
+#define PAPI_AMDSMI_LINK_TYPE_PCIE AMDSMI_LINK_TYPE_PCIE
+#elif defined(AMDSMI_IOLINK_TYPE_PCIE)
+#define PAPI_AMDSMI_LINK_TYPE_PCIE AMDSMI_IOLINK_TYPE_PCIE
+#else
+#define PAPI_AMDSMI_LINK_TYPE_PCIE 0
+#endif
+
 /* Mode enumeration used by accessors */
 typedef enum {
   PAPI_MODE_READ = 1,


### PR DESCRIPTION
## Summary
- add compile-time aliases so amdsmi_io_link_type_t and amdsmi_link_type_t work across AMD SMI v25/v26
- normalize link type constants and event registration logic to use version-agnostic helpers
- require AMD SMI v25+ during compilation to avoid unsupported headers

## Testing
- `make -C src components`


------
https://chatgpt.com/codex/tasks/task_e_68cc5b9c2880832ba7f07e6113c9799c