### PR TITLE
Add encoded event codes and device-aware AMD SMI context handling

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -767,6 +767,7 @@ static int add_event(int *idx_ptr, const char *name, const char *descr, int devi
   if (!ev->name || !ev->descr)
     return PAPI_ENOMEM;
   ev->device = device;
+  ev->device_map = 0;
   ev->value = 0;
   ev->mode = mode;
   ev->variant = variant;

--- a/src/components/amd_smi/amds_evtapi.c
+++ b/src/components/amd_smi/amds_evtapi.c
@@ -9,8 +9,9 @@
 #include "amds_priv.h"
 #include "htable.h"
 #include "papi.h"
-#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* Event enumeration: iterate over native events */
 int amds_evt_enum(unsigned int *EventCode, int modifier) {
@@ -48,10 +49,18 @@ int amds_evt_code_to_name(unsigned int EventCode, char *name, int len) {
   if (!ntv_table_p) {
     return PAPI_ECMP;
   }
-  if (EventCode >= (unsigned int)ntv_table_p->count) {
+  event_info_t info;
+  uint64_t code = (uint64_t)EventCode;
+  decode_event_code(code, &info);
+  if (info.nameid < 0 || info.nameid >= ntv_table_p->count) {
     return PAPI_EINVAL;
   }
-  snprintf(name, (size_t)len, "%s", ntv_table_p->events[EventCode].name);
+  native_event_t *event = &ntv_table_p->events[info.nameid];
+  if ((info.flags & DEVICE_FLAG) && event->device < 0) {
+    snprintf(name, (size_t)len, "%s:device=%d", event->name, info.device);
+  } else {
+    snprintf(name, (size_t)len, "%s", event->name);
+  }
   return PAPI_OK;
 }
 
@@ -64,10 +73,69 @@ int amds_evt_name_to_code(const char *name, unsigned int *EventCode) {
   }
   native_event_t *event = NULL;
   int hret = htable_find(htable, name, (void **)&event);
-  if (hret != HTABLE_SUCCESS) {
-    return (hret == HTABLE_ENOVAL) ? PAPI_ENOEVNT : PAPI_ECMP;
+  if (hret == HTABLE_SUCCESS) {
+    if ((uint64_t)event->id > NAMEID_MASK) {
+      return PAPI_EINVAL;
+    }
+    event_info_t info;
+    info.device = 0;
+    info.flags = 0;
+    info.nameid = (int)event->id;
+    uint64_t code64 = encode_event_code(&info);
+    *EventCode = (unsigned int)code64;
+    return PAPI_OK;
   }
-  *EventCode = event->id;
+
+  if (hret != HTABLE_ENOVAL) {
+    return PAPI_ECMP;
+  }
+
+  const char *pos = strstr(name, ":device=");
+  if (!pos) {
+    return PAPI_ENOEVNT;
+  }
+
+  char *endptr = NULL;
+  long dev_no = strtol(pos + 8, &endptr, 10);
+  if (endptr == pos + 8 || (*endptr != '\0' && *endptr != ':')) {
+    return PAPI_ENOEVNT;
+  }
+  if (dev_no < 0) {
+    return PAPI_ENOEVNT;
+  }
+  int dev = (int)dev_no;
+
+  char base_name[PAPI_MAX_STR_LEN];
+  size_t prefix_len = (size_t)(pos - name);
+  if (prefix_len >= sizeof(base_name)) {
+    return PAPI_EINVAL;
+  }
+  memcpy(base_name, name, prefix_len);
+  base_name[prefix_len] = '\0';
+  if (*endptr == ':') {
+    size_t remaining = strlen(endptr);
+    if (prefix_len + remaining >= sizeof(base_name)) {
+      return PAPI_EINVAL;
+    }
+    strncat(base_name, endptr, sizeof(base_name) - strlen(base_name) - 1);
+  }
+
+  hret = htable_find(htable, base_name, (void **)&event);
+  if (hret != HTABLE_SUCCESS) {
+    return PAPI_ENOEVNT;
+  }
+  if (event->device >= 0) {
+    return PAPI_ENOEVNT;
+  }
+  if ((uint64_t)event->id > NAMEID_MASK) {
+    return PAPI_EINVAL;
+  }
+  event_info_t info;
+  info.device = dev;
+  info.flags = DEVICE_FLAG;
+  info.nameid = (int)event->id;
+  uint64_t code64 = encode_event_code(&info);
+  *EventCode = (unsigned int)code64;
   return PAPI_OK;
 }
 
@@ -78,9 +146,13 @@ int amds_evt_code_to_descr(unsigned int EventCode, char *descr, int len) {
   if (!ntv_table_p) {
     return PAPI_ECMP;
   }
-  if (EventCode >= (unsigned int)ntv_table_p->count) {
+  event_info_t info;
+  uint64_t code = (uint64_t)EventCode;
+  decode_event_code(code, &info);
+  if (info.nameid < 0 || info.nameid >= ntv_table_p->count) {
     return PAPI_EINVAL;
   }
-  snprintf(descr, (size_t)len, "%s", ntv_table_p->events[EventCode].descr);
+  native_event_t *event = &ntv_table_p->events[info.nameid];
+  snprintf(descr, (size_t)len, "%s", event->descr);
   return PAPI_OK;
 }


### PR DESCRIPTION
## Summary
- add helper structures and bitfield helpers for encoding AMD SMI event metadata into event codes
- update event API helpers to parse encoded codes and support optional :device qualifiers
- teach AMD SMI context management to decode event codes, resolve devices, and safely invoke callbacks

## Testing
- make *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b0058b08832ba52f2983260ada4f