### PR TITLE
Fix default event selection in amdsmi_hello test

### DIFF
--- a/src/components/amd_smi/tests/amdsmi_hello.c
+++ b/src/components/amd_smi/tests/amdsmi_hello.c
@@ -58,21 +58,22 @@ int main(int argc, char** argv) {
             }
         }
         if (cid < 0) {
-        int qualified = 0;
-        if (harness_select_device_qualified_event_name(cid, code, &qualified,
-                                                       ev_buf, sizeof(ev_buf)) != PAPI_OK ||
-            ev_buf[0] == '\0') {
-        ev = ev_buf;
+            SKIP("Unable to locate the amd_smi component (PAPI built without ROCm?)");
         }
 
-        int code = PAPI_NATIVE_MASK;
-        if (PAPI_enum_cmp_event(&code, PAPI_ENUM_FIRST, cid) != PAPI_OK) {
+        int base_code = PAPI_NATIVE_MASK;
+        if (PAPI_enum_cmp_event(&base_code, PAPI_ENUM_FIRST, cid) != PAPI_OK) {
             SKIP("No native events found for AMD-SMI component");
         }
-        if (PAPI_event_code_to_name(code, ev_auto) != PAPI_OK || ev_auto[0] == '\0') {
+
+        int qualified_code = base_code;
+        if (harness_select_device_qualified_event_name(cid, base_code, &qualified_code,
+                                                       ev_buf, sizeof(ev_buf)) != PAPI_OK ||
+            ev_buf[0] == '\0') {
             SKIP("Could not obtain first AMD-SMI event name");
         }
-        ev = ev_auto;
+
+        ev = ev_buf;
         NOTE("Defaulting to first AMD-SMI event: %s", ev);
     }
 


### PR DESCRIPTION
## Summary
- fix the default AMD-SMI event lookup when no event name is provided
- use the harness helper to resolve a qualified event name and emit a helpful message

## Testing
- make -C src/components/amd_smi/tests amdsmi_hello

------
https://chatgpt.com/codex/tasks/task_e_68d4a0f46210832b89ffc4e2d711cb68